### PR TITLE
Réparer le bouton de la modale

### DIFF
--- a/example_app/templates/example_app/blocks/footer.html
+++ b/example_app/templates/example_app/blocks/footer.html
@@ -3,6 +3,8 @@
 {% block footer_links %}
   {{ block.super }}
   <li class="fr-footer__bottom-item">
-    <button class="fr-btn--display fr-btn" aria-controls="fr-theme-modal" data-fr-opened="false">Paramètres d’affichage</button>
+    <button id="footer__bottom-link__parametres-affichage" aria-controls="fr-theme-modal" data-fr-opened="false" class="fr-icon-theme-fill fr-link--icon-left fr-footer__bottom-link" data-fr-js-modal-button="true">
+      Paramètres d'affichage
+    </button>
   </li>
 {% endblock footer_links %}

--- a/example_app/templates/example_app/blocks/footer.html
+++ b/example_app/templates/example_app/blocks/footer.html
@@ -4,7 +4,7 @@
   {{ block.super }}
   <li class="fr-footer__bottom-item">
     <button id="footer__bottom-link__parametres-affichage" aria-controls="fr-theme-modal" data-fr-opened="false" class="fr-icon-theme-fill fr-link--icon-left fr-footer__bottom-link" data-fr-js-modal-button="true">
-      Paramètres d'affichage
+      Paramètres d’affichage
     </button>
   </li>
 {% endblock footer_links %}


### PR DESCRIPTION
## 🎯 Objectif
Le bouton de la modale est décalé sur le site d’exemple par rapport au reste de la ligne, parce qu'il utilise une classe obsolète.

## 🔍 Implémentation
- [x] Implémente la nouvelle version du bouton