### PR TITLE
Utilisation d'un moteur de rendu de template custom sur la classe `DsfrDjangoTemplates`

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -62,10 +62,7 @@ ROOT_URLCONF = "example.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [
-            os.path.join(BASE_DIR, "dsfr/templates"),
-            os.path.join(BASE_DIR, "templates"),
-        ],
+        "DIRS": [],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -78,8 +75,6 @@ TEMPLATES = [
         },
     },
 ]
-
-FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 WSGI_APPLICATION = "example.wsgi.application"
 


### PR DESCRIPTION
## 🎯 Objectif

Utilisation d'un moteur de rendu de template custom sur la classe `DsfrDjangoTemplates`

## ⚠️ Informations supplémentaires

Cette modification permet de se passer de modifier les paramètres `FORM_RENDERER` et `TEMPLATES.DIRS` dans le `settings.py` et de limiter l'utilisation des templates dans `dsfr/templates/django/forms/widgets` aux formulaires rendus avec la classe `DsfrBaseForm`.

Nous avons actuellement ce besoin sur [betagouv/Aidants_Connect](https://github.com/betagouv/Aidants_Connect) puisqu'une partie du site est en DSFR et une partie est sur un ancien design. Les templates dans `dsfr/templates/django/forms/widgets` cassent une partie des pages qui sont sur l'ancien design.

Je n'ai pas trouvé où modifier la documentation.