### PR TITLE
Design plus intégré du rendu des erreurs Django

### DIFF
--- a/dsfr/static/css/dsfr-django-overrides.css
+++ b/dsfr/static/css/dsfr-django-overrides.css
@@ -1,0 +1,11 @@
+.errorlist {
+  margin-top: 1rem;
+}
+
+.errorlist .fr-error-text {
+  margin-top: 0;
+}
+
+.errorlist.nonfield {
+  padding: 1rem;
+}

--- a/dsfr/templates/django/forms/errors/dict/ul.html
+++ b/dsfr/templates/django/forms/errors/dict/ul.html
@@ -1,0 +1,1 @@
+{% if errors %}<ul class="{{ error_class }}">{% for field, error in errors %}<li class="fr-error-text">{{ field }}{{ error }}</li>{% endfor %}</ul>{% endif %}

--- a/dsfr/templates/django/forms/errors/list/ul.html
+++ b/dsfr/templates/django/forms/errors/list/ul.html
@@ -1,0 +1,1 @@
+{% if errors %}<ul class="{{ error_class }}">{% for error in errors %}<li class="fr-error-text">{{ error }}</li>{% endfor %}</ul>{% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
@@ -16,7 +16,7 @@
     </label>
 
     {% if field.errors %}
-      <div id="{{ field.auto_id }}-desc-error" class="fr-error-text">
+      <div id="{{ field.auto_id }}-desc-error">
         {{ field.errors }}
       </div>
     {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
@@ -24,7 +24,7 @@
   </div>
 
   {% if field.errors %}
-  <div id="{{ field.auto_id }}-messages" class="fr-error-text">
+  <div id="{{ field.auto_id }}-messages">
     {{ field.errors }}
   </div>
 {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
@@ -15,7 +15,7 @@
     {% endif %}
 
     {% if field.errors %}
-      <div id="{{ field.auto_id }}-desc-error" class="fr-error-text">
+      <div id="{{ field.auto_id }}-desc-error">
         {{ field.errors }}
       </div>
     {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
@@ -16,7 +16,7 @@
   </div>
 
   {% if field.errors %}
-    <div class="fr-messages-group fr-error-text" id="{{ field.auto_id }}-messages">
+    <div class="fr-messages-group" id="{{ field.auto_id }}-messages">
         {{ field.errors }}
     </div>
   {% endif %}

--- a/dsfr/templates/dsfr/form_snippet.html
+++ b/dsfr/templates/dsfr/form_snippet.html
@@ -1,3 +1,6 @@
+{% if form.non_field_errors %}
+  <section class="fr-my-4v fr-input-group fr-input-group--error">{{ form.non_field_errors }}</section>
+{% endif %}
 {% for field in form %}
     {% include "dsfr/form_field_snippets/field_snippet.html" %}
 {% endfor %}

--- a/dsfr/templates/dsfr/global_css.html
+++ b/dsfr/templates/dsfr/global_css.html
@@ -1,5 +1,6 @@
 {% load static %}
 <link rel="stylesheet" href="{% static 'dsfr/dist/dsfr/dsfr.min.css' %}" integrity="{{ self.INTEGRITY_CSS }}">
 <link rel="stylesheet" href="{% static 'dsfr/dist/utility/icons/icons.min.css' %}" integrity="{{ self.INTEGRITY_CSS_ICONS }}">
+<link rel="stylesheet" href="{% static 'css/dsfr-django-overrides.css' %}">
 
 <meta name="theme-color" content="#000091"><!-- Définit la couleur de thème du navigateur (Safari/Android) -->


### PR DESCRIPTION
## 🎯 Objectif

Design plus intégré du rendu des erreurs Django. Cette PR rajoute le fichier `dsfr/static/css/dsfr-django-overrides.css`. Il y a peut-être de la doc à modifier ?

## 🔍 Implémentation

- Meilleure intégration du DSFR dans les erreurs Django
- Affichage des erreurs générales lors de l'utilisation de `{% dsfr_form %}`

## 🖼️ Images

### Avant :

![](https://github.com/numerique-gouv/django-dsfr/assets/22097904/104aae28-9e5d-48a9-be2d-1407da0c268e)

### Après : 

![](https://github.com/numerique-gouv/django-dsfr/assets/22097904/e9e1f4d8-a722-4dab-b24f-9df20b400db7)

