### PR TITLE
Ajout d'une balise pour rendre les messages Django

### DIFF
--- a/dsfr/templates/dsfr/alert.html
+++ b/dsfr/templates/dsfr/alert.html
@@ -1,5 +1,5 @@
 <div role="alert" class="fr-alert fr-alert--{{ self.type }}{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}">
-  <{{ self.heading_tag | default:"p" }} class="fr-alert__title">{{ self.title }}</{{ self.heading_tag | default:"p" }}>
+  {% if self.title %}<{{ self.heading_tag | default:"p" }} class="fr-alert__title">{{ self.title }}</{{ self.heading_tag | default:"p" }}>{% endif %}
   <p>{{ self.content | safe }}</p>
   {% if self.is_collapsible %}
     <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -223,23 +223,70 @@ def dsfr_django_messages(
 ):
     """
     Renders django messages in a series a DSFR alerts
-        data_dict = {
+    
+    ```python
+    data_dict = {
         "is_collapsible" : "(Optional) Boolean, set to true to add a 'close' button for the alert (default: false)",
         "wrapper_classes": (Optional) extra classes for the wrapper of the alerts (default "fr-my-4v").
         "extra_classes": (Optional) extra classes for the alert.
     }
+    ```
 
     All of the keys of the dict can be passed directly as named parameters of the tag.
 
     Relevant extra_classes
-    - "fr-alert--sm" : small alert
+    - `fr-alert--sm` : small alert
 
-    See: https://docs.djangoproject.com/en/4.2/ref/contrib/messages/
+    See: [https://docs.djangoproject.com/en/4.2/ref/contrib/messages/](https://docs.djangoproject.com/en/4.2/ref/contrib/messages/)
 
-    **Tag name**::
+    By default, the following message level are mapped to the following alert types:
+    
+    Message level | DSFR alert type
+    :------------:|:--------------:
+    `DEBUG`       | `info`
+    `INFO`        | `info`
+    `SUCCESS`     | `success`
+    `WARNING`     | `warning`
+    `ERROR`       | `error`
+    
+    There types are then concatenated with ``fr-alert--`` to form the CSS classe in the template.
+    
+    These classes can be modified by setting ``DSFR_MESSAGE_TAGS_CSS_CLASSES`` in your ``settings.py``, like so:
+    
+    ```python
+    from django.contrib import messages
+    DSFR_MESSAGE_TAGS_CSS_CLASSES = {
+        messages.DEBUG: "error"
+    }
+    ```
+    
+    You can also use this setting to map [custom custom message levels](https://docs.djangoproject.com/en/4.2/ref/contrib/messages/#creating-custom-message-levels) 
+    to alert types:
+    
+    ```python
+    django.conf import global_settings
+    from django.contrib import messages
+    MESSAGE_TAGS = {
+        50: "fatal"
+    }
+    DSFR_MESSAGE_TAGS_CSS_CLASSES = {
+        messages.DEBUG: "debug",
+        50: "warning"
+    }
+    ```
+        
+    With this setting, the following code:
+    
+    ```python
+    messages.add_message(request, 50, "A serious error occurred.")
+    ```
+
+    renders an alert with the following CSS class: `fr-alert--warning`.
+
+    **Tag name**:
         dsfr_django_messages
-    **Usage**::
-        {% dsfr_django_messages data_dict %}
+    **Usage**:
+        `{% dsfr_django_messages data_dict %}`
     """  # noqa
 
     messages = context.get("messages")

--- a/example_app/tag_specifics.py
+++ b/example_app/tag_specifics.py
@@ -604,6 +604,7 @@ EXTRA_TAGS = {
     "js": {"title": "JS global"},
     "form": {"title": "Formulaire"},
     "form_field": {"title": "Formulaire - champ"},
+    "django_messages": {"title": "Messages Django dans une alerte"}
 }
 
 unsorted_implemented_tags = {**IMPLEMENTED_TAGS, **EXTRA_TAGS}

--- a/example_app/views.py
+++ b/example_app/views.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 import markdown
 from markdown.extensions.codehilite import CodeHiliteExtension
 import os
@@ -6,6 +8,7 @@ from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.http import require_safe
+from markdown.extensions.nl2br import Nl2BrExtension
 
 from dsfr.utils import generate_summary_items
 
@@ -102,8 +105,10 @@ def page_tag(request, tag_name):
 
         module = getattr(globals()["dsfr_tags"], f"dsfr_{tag_name}")
         payload["tag_comment"] = markdown.markdown(
-            module.__doc__,
+            dedent(module.__doc__),
             extensions=[
+                "markdown.extensions.tables",
+                "markdown.extensions.nl2br",  # Treat newlines as linebreaks
                 "markdown.extensions.fenced_code",
                 CodeHiliteExtension(css_class="dsfr-code"),
             ],


### PR DESCRIPTION
## 🎯 Objectif

Ajout d'une balise pour rendre les messages Django. Cette PR rend aussi le titre de notification de la balise `dsfr_alert` optionnel.

## 🖼️ Images

Rendu : 

![](https://github.com/numerique-gouv/django-dsfr/assets/22097904/2eee16a7-2529-4780-9381-ebeebf43aa56)
