### PR TITLE
Petit fix sur le default_renderer de DsfrBaseForm et màj de la documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,7 @@
 ```{ .bash }
 pip install django-dsfr
 ```
+### Pour Django 5.0+
 
 - Ajoutez `widget_tweaks` et `dsfr` à `INSTALLED_APPS` dans le `settings.py` avant la ou les app avec laquelle vous voulez l’utiliser :
 
@@ -19,25 +20,29 @@ INSTALLED_APPS = [
 ]
 ```
 
-- Ajouter les lignes suivantes dans la section `TEMPLATES` du `settings.py` pour faire fonctionner les formulaires :
+### Pour Django 4.2 et avant
+
+- Ajoutez `widget_tweaks`, `dsfr` et `django.forms` à `INSTALLED_APPS` dans le `settings.py` avant la ou les app avec laquelle vous voulez l’utiliser :
 
 ```{ .python }
-TEMPLATES = [
-    {
-        [...]
-        "DIRS": [
-            os.path.join(BASE_DIR, "dsfr/templates"),
-            os.path.join(BASE_DIR, "templates"),
-        ],
-    },
+INSTALLED_APPS = [
+    ...
+    "widget_tweaks"
+    "dsfr",
+    "django.forms",
+    <votre_app>
 ]
 ```
+
+**Attention** : si `django.forms` apparait déjà dans `INSTALLED_APPS`, il doit être placé *après* `dsfr`. Sinon les `FormSet`s ne seront pas correctement rendus.
 
 - Ajouter le `FORM_RENDERER` in `settings.py` pour faire fonctionner les formulaires :
 
 ```{ .python }
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 ```
+
+### Pour toutes les versions
 
 - Inclure les tags dans votre fichier `base.html` (voir par exemple sur [base.html](https://github.com/numerique-gouv/django-dsfr/blob/main/example_app/templates/example_app/base.html))
 

--- a/dsfr/forms.py
+++ b/dsfr/forms.py
@@ -36,11 +36,12 @@ class DsfrBaseForm(forms.Form):
     @property
     def default_renderer(self):
         from django.conf import settings, global_settings
-        # Settings wasn't modified
-        if settings.FORM_RENDERER == global_settings.FORM_RENDERER:
-            return DsfrDjangoTemplates
-        else:
-            get_default_renderer()
+
+        return (
+            DsfrDjangoTemplates  # Settings wasn't modified
+            if settings.FORM_RENDERER == global_settings.FORM_RENDERER
+            else get_default_renderer()
+        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/example/settings.py
+++ b/example/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 
 from pathlib import Path
 import os
+from django import VERSION as DJANGO_VERSION
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -37,7 +38,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "django.forms",
     "django_extensions",
     "csp",
     "widget_tweaks",
@@ -45,6 +45,9 @@ INSTALLED_APPS = [
     "example_app",
     "django_distill",
 ]
+
+if DJANGO_VERSION < (5, 0):
+    INSTALLED_APPS.append("django.forms")
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -75,6 +78,9 @@ TEMPLATES = [
         },
     },
 ]
+
+if DJANGO_VERSION < (5, 0):
+    FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 WSGI_APPLICATION = "example.wsgi.application"
 


### PR DESCRIPTION
## 🎯 Objectif

Si `settings.FORM_RENDERER != global_settings.FORM_RENDERER`, la propriété ne retourne rien. Cette PR résout ce problème.