### PR TITLE
Configuration des classes CSS dans le template en même temps que dans le Form

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
@@ -1,11 +1,11 @@
-{% load widget_tweaks %}
+{% load widget_tweaks dsfr_tags %}
 <div class="fr-checkbox-group{% if field.errors %} fr-checkbox-group--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %}">
   {% if field.errors %}
     {% with aria_describedby="aria-describedby:"|add:field.auto_id|add:"-desc-error" %}
-      {{ field|attr:"type:checkbox"|attr:aria_describedby }}
+      {{ field|dsfr_input_class_attr|attr:"type:checkbox"|attr:aria_describedby }}
     {% endwith %}
   {% else %}
-    {{ field|attr:"type:checkbox" }}
+    {{ field|dsfr_input_class_attr|attr:"type:checkbox" }}
   {% endif %}
   <label for="{{ field.id_for_label }}" class="fr-label">
     {{ field.label_tag }}

--- a/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
@@ -1,4 +1,4 @@
-{% load widget_tweaks %}
+{% load widget_tweaks dsfr_tags %}
 <fieldset class="fr-fieldset{% if field.errors %} fr-fieldset--error{% endif %}"
           id="checkboxes-{{ field.auto_id }}"
           aria-labelledby="{{ field.auto_id }}-legend{% if field.errors %} {{ field.auto_id }}-messages{% endif %}">
@@ -16,10 +16,10 @@
     <div class="fr-checkbox-group{% if field.errors %} fr-checkbox-group--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %}">
       {% if field.errors %}
         {% with aria_describedby="aria-describedby:"|add:field.auto_id|add:"-desc-error" %}
-          {{ field|attr:"type:checkbox"|attr:aria_describedby }}
+          {{ field|dsfr_input_class_attr|attr:"type:checkbox"|attr:aria_describedby }}
         {% endwith %}
       {% else %}
-        {{ field|attr:"type:checkbox" }}
+        {{ field|dsfr_input_class_attr|attr:"type:checkbox" }}
       {% endif %}
       {% if field.errors %}
         <div id="{{ field.auto_id }}-desc-error" class="fr-error-text">

--- a/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
@@ -1,21 +1,18 @@
-{% load widget_tweaks %}
+{% load widget_tweaks dsfr_tags %}
 {# Generic input snippet used by most of the field types #}
 <div class="{{ field.field.widget.group_class|default:'fr-input-group' }}{% if field.errors %} {{ field.field.widget.group_class|default:'fr-input-group' }}--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %}">
   <label for="{{ field.id_for_label }}" class="fr-label">
-    {{ field.label }}
-    {% if field.field.required %}
-      *
-    {% endif %}
+    {{ field.label }}{% if field.field.required %}*{% endif %}
     {% if field.help_text %}
       <span class="fr-hint-text">{{ field.help_text }}</span>
     {% endif %}
   </label>
   {% if field.errors %}
     {% with aria_describedby="aria-describedby:"|add:field.auto_id|add:"-desc-error" %}
-      {{ field|attr:"aria-invalid:true"|attr:aria_describedby }}
+      {{ field|dsfr_input_class_attr|attr:"aria-invalid:true"|attr:aria_describedby }}
     {% endwith %}
   {% else %}
-    {{ field }}
+    {{ field|dsfr_input_class_attr }}
   {% endif %}
   {% if field.errors %}
     <div id="{{ field.auto_id }}-desc-error">

--- a/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
@@ -1,4 +1,4 @@
-{% load widget_tweaks %}
+{% load widget_tweaks dsfr_tags %}
 <fieldset class="fr-fieldset{% if field.errors %} fr-fieldset--error{% endif %}"
           id="radio-{{ field.auto_id }}"
           aria-labelledby="{{ field.auto_id }}-legend{% if field.errors %} {{ field.auto_id }}-messages{% endif %}">
@@ -15,9 +15,9 @@
   <div class="fr-fieldset__content">
     <div class="fr-radio-group">
       {% if field.field.disabled %}
-        {{ field|attr:"type:radio"|add_class:"fr-radio-group"|attr:"disabled" }}
+        {{ field|dsfr_input_class_attr|attr:"type:radio"|attr:"disabled" }}
       {% else %}
-        {{ field|attr:"type:radio"|add_class:"fr-radio-group" }}
+        {{ field|dsfr_input_class_attr|attr:"type:radio" }}
       {% endif %}
     </div>
   </div>

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1,7 +1,8 @@
-from django import template
+from django import template, forms
 from django.conf import settings
 from django.contrib.messages.constants import DEBUG, INFO, SUCCESS, WARNING, ERROR
 from django.core.paginator import Page
+from django.forms import BoundField
 from django.template import Template
 from django.template.context import Context
 from django.utils.html import format_html, format_html_join
@@ -20,6 +21,7 @@ from dsfr.utils import (
     find_active_menu_items,
     generate_random_id,
     parse_tag_args,
+    dsfr_input_class_attr,
 )
 
 register = template.Library()
@@ -118,6 +120,9 @@ def dsfr_form_field(field) -> dict:
         `{% dsfr_form_field field %}`
     """
     return {"field": field}
+
+
+register.filter(name="dsfr_input_class_attr", filter_func=dsfr_input_class_attr)
 
 
 @register.inclusion_tag("dsfr/theme_modale.html")

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -1,3 +1,4 @@
+from django.forms import BoundField, widgets
 from django.core.paginator import Page
 from django.utils.text import slugify
 import random
@@ -103,3 +104,27 @@ def generate_summary_items(sections_names: list) -> list:
         )
 
     return items
+
+
+def dsfr_input_class_attr(bf: BoundField):
+    if not bf.is_hidden and "class" not in bf.field.widget.attrs:
+        if isinstance(
+            bf.field.widget, (widgets.Select, widgets.SelectMultiple)
+        ):
+            bf.field.widget.attrs["class"] = "fr-select"
+            bf.field.widget.group_class = "fr-select-group"
+        elif isinstance(bf.field.widget, widgets.RadioSelect):
+            bf.field.widget.attrs["dsfr"] = "dsfr"
+            bf.field.widget.group_class = "fr-radio-group"
+        elif isinstance(bf.field.widget, widgets.CheckboxSelectMultiple):
+            bf.field.widget.attrs["dsfr"] = "dsfr"
+        elif not isinstance(
+            bf.field.widget,
+            (
+                widgets.CheckboxInput,
+                widgets.FileInput,
+                widgets.ClearableFileInput,
+            ),
+        ):
+            bf.field.widget.attrs["class"] = "fr-input"
+    return bf


### PR DESCRIPTION
## 🎯 Objectif

`dsfr_form_field` est inutile s'il n'est pas utilisé avec `DsfrBaseForm` puisque la classe CSS est paramétrée dans `DsfrBaseForm`. C'est la seule chose qui est configurée au niveau du formulaire et pas au niveau template, ce qui est contre-intuitif.

Cette PR ajoute cette logique dans un filtre à utilisé sur chaque `field`.