### PR TITLE
Ajoute une page pour montrer la gestion des couleurs

### DIFF
--- a/dsfr/constants.py
+++ b/dsfr/constants.py
@@ -1,0 +1,50 @@
+# Color palettes, per https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-de-l-identite-de-l-etat/couleurs-palette/
+
+COLOR_CHOICES_PRIMARY = [
+    ("blue-france", "Bleu France"),
+    ("red-marianne", "Rouge Marianne"),
+]
+
+COLOR_CHOICES_NEUTRAL = [
+    ("grey", "Gris"),
+]
+
+COLOR_CHOICES_SYSTEM = [
+    ("info", "Info"),
+    ("success", "Succès"),
+    ("warning", "Avertissement"),
+    ("error", "Erreur"),
+]
+
+COLOR_CHOICES_ILLUSTRATION = [
+    ("green-tilleul-verveine", "Thilleul verveine"),
+    ("green-bourgeon", "Bourgeon"),
+    ("green-emeraude", "Émeraude"),
+    ("green-menthe", "Menthe"),
+    ("green-archipel", "Archipel"),
+    ("blue-ecume", "Écume"),
+    ("blue-cumulus", "Cumulus"),
+    ("purple-glycine", "Glycine"),
+    ("pink-macaron", "Macaron"),
+    ("pink-tuile", "Tuile"),
+    ("yellow-tournesol", "Tournesol"),
+    ("yellow-moutarde", "Moutarde"),
+    ("orange-terre-battue", "Terre battue"),
+    ("brown-cafe-creme", "Café crème"),
+    ("brown-caramel", "Caramel"),
+    ("brown-opera", "Opéra"),
+    ("beige-gris-galet", "Gris galet"),
+]
+
+COLOR_CHOICES = [
+    ("Couleurs primaires", COLOR_CHOICES_PRIMARY),
+    ("Couleurs neutres", COLOR_CHOICES_NEUTRAL),
+    ("Couleurs illustratives", COLOR_CHOICES_ILLUSTRATION),
+]
+
+COLOR_CHOICES_WITH_SYSTEM = [
+    ("Couleurs primaires", COLOR_CHOICES_PRIMARY),
+    ("Couleurs neutres", COLOR_CHOICES_NEUTRAL),
+    ("Couleurs système", COLOR_CHOICES_SYSTEM),
+    ("Couleurs illustratives", COLOR_CHOICES_ILLUSTRATION),
+]

--- a/dsfr/templates/dsfr/base.html
+++ b/dsfr/templates/dsfr/base.html
@@ -14,9 +14,9 @@
     {% block title %}
       <title>
         {% if title %}
-          {{ title }} — Système de Design de l’État
+          {{ title }} — {{ SITE_CONFIG.site_title }}
         {% else %}
-          Système de Design de l’État
+          {{ SITE_CONFIG.site_title }}
         {% endif %}
       </title>
     {% endblock title %}

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1,8 +1,7 @@
-from django import template, forms
+from django import template
 from django.conf import settings
 from django.contrib.messages.constants import DEBUG, INFO, SUCCESS, WARNING, ERROR
 from django.core.paginator import Page
-from django.forms import BoundField
 from django.template import Template
 from django.template.context import Context
 from django.utils.html import format_html, format_html_join
@@ -897,7 +896,7 @@ def dsfr_skiplinks(context: Context, items: list) -> dict:
         if "skiplinks" in context:
             items = context["skiplinks"]
         else:
-            items = {}
+            items = []
     return {"self": {"items": items}}
 
 

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -44,10 +44,10 @@ def parse_tag_args(args, kwargs, allowed_keys: list) -> dict:
     """
     Allows to use a tag with either all the arguments in a dict or by declaring them separately
     """
+    tag_data = {}
+
     if args:
-        tag_data = args[0]
-    else:
-        tag_data = {}
+        tag_data = args[0].copy()
 
     for k in kwargs:
         if k in allowed_keys:
@@ -108,9 +108,7 @@ def generate_summary_items(sections_names: list) -> list:
 
 def dsfr_input_class_attr(bf: BoundField):
     if not bf.is_hidden and "class" not in bf.field.widget.attrs:
-        if isinstance(
-            bf.field.widget, (widgets.Select, widgets.SelectMultiple)
-        ):
+        if isinstance(bf.field.widget, (widgets.Select, widgets.SelectMultiple)):
             bf.field.widget.attrs["class"] = "fr-select"
             bf.field.widget.group_class = "fr-select-group"
         elif isinstance(bf.field.widget, widgets.RadioSelect):

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -4,6 +4,7 @@ from django.forms import (
     inlineformset_factory,
 )  # /!\ In order to use formsets
 
+from dsfr.constants import COLOR_CHOICES_ILLUSTRATION
 from dsfr.forms import DsfrBaseForm
 
 # /!\ In order to use formsets
@@ -211,3 +212,11 @@ BookCreateFormSet = inlineformset_factory(
     extra=1,
     exclude=[],
 )
+
+
+class ColorForm(DsfrBaseForm):
+    color = forms.ChoiceField(
+        label="Choisissez une couleur",
+        required=False,
+        choices=[("", "----")] + COLOR_CHOICES_ILLUSTRATION,
+    )

--- a/example_app/templates/example_app/blocks/header.html
+++ b/example_app/templates/example_app/blocks/header.html
@@ -121,6 +121,13 @@
             <div class="fr-collapse fr-menu" id="menu-resources">
               <ul class="fr-menu__list">
                 <li>
+                  {% url 'resource_colors' as resource_colors_url %}
+                  <a class="fr-nav__link"
+                     href="{{ resource_colors_url }}"
+                     target="_self"
+                     {% if request.path == resource_colors_url %}aria-current="true"{% endif %}>Couleurs</a>
+                </li>
+                <li>
                   {% url 'resource_icons' as resource_icons_url %}
                   <a class="fr-nav__link"
                      href="{{ resource_icons_url }}"

--- a/example_app/templates/example_app/page_colors.html
+++ b/example_app/templates/example_app/page_colors.html
@@ -1,0 +1,156 @@
+{% extends "example_app/base.html" %}
+{% load static dsfr_tags %}
+{% block content %}
+  <h1>
+    Couleurs
+  </h1>
+  <ul class="fr-mb-4w">
+    <li>
+      <a class="fr-link fr-icon-external-link-line fr-link--icon-right fr-link--lg"
+         href="https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-de-l-identite-de-l-etat/couleurs-palette/"
+         target="_blank"
+         rel="noopener noreferrer">
+        Voir la page de présentation de la palette de couleurs sur le Système de Design de l’État <span class="fr-sr-only">Ouvre une nouvelle fenêtre</span>
+      </a>
+    </li>
+    <li>
+      <a class="fr-link fr-icon-external-link-line fr-link--icon-right fr-link--lg"
+         href="https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-de-l-identite-de-l-etat/couleurs-utilisation-dans-le-dsfr"
+         target="_blank"
+         rel="noopener noreferrer">
+        Voir la page de règles d’utilisation de la palette de couleurs sur le Système de Design de l’État <span class="fr-sr-only">Ouvre une nouvelle fenêtre</span>
+      </a>
+    </li>
+  </ul>
+  <h2>
+    Cartes et tuiles
+  </h2>
+  <p>
+    Les cartes et tuiles peuvent prendre un fond gris à la place de la couleur par défaut.
+  </p>
+  <div class="fr-grid-row fr-grid-row--gutters fr-mb-4w">
+    <div class="fr-col-12 fr-col-md-6">
+      {% dsfr_card components_data.card.sample_data.0 %}
+    </div>
+    <div class="fr-col-12 fr-col-md-6">
+      {% dsfr_card components_data.card.sample_data.0 extra_classes="fr-card--grey" %}
+    </div>
+  </div>
+  <div class="fr-grid-row fr-grid-row--gutters fr-mb-4w">
+    <div class="fr-col-12 fr-col-md-3">
+      {% dsfr_tile components_data.tile.sample_data.0 %}
+    </div>
+    <div class="fr-col-12 fr-col-md-3">
+      {% dsfr_tile components_data.tile.sample_data.0 extra_classes="fr-tile--grey" %}
+    </div>
+    <div class="fr-col-12 fr-col-md-3">
+      {% dsfr_tile components_data.tile.sample_data.0 %}
+    </div>
+    <div class="fr-col-12 fr-col-md-3">
+      {% dsfr_tile components_data.tile.sample_data.0 extra_classes="fr-tile--grey" %}
+    </div>
+  </div>
+  <h2>
+    Couleurs d’accentuation
+  </h2>
+  <p>
+    Certains composants prennent une couleur d’accentuation comme paramètre. Seules les couleurs illustratives sont prises en compte.
+  </p>
+  <form class="fr-mb-4w">
+    {% dsfr_form %}
+  </form>
+  <div class="example-use">
+    <h3>
+      Citation
+    </h3>
+    <p>
+      Personnalise la couleur de l’icône.
+    </p>
+    {% dsfr_quote components_data.quote.sample_data.0 %}
+    <h3>
+      Mise en avant
+    </h3>
+    <p>
+      Personnalise la couleur du fond et de la bordure.
+    </p>
+    {% dsfr_callout components_data.callout.sample_data.0 %}
+    <h3>
+      Mise en exergue
+    </h3>
+    <p>
+      Personnalise la couleur de la bordure.
+    </p>
+    {% dsfr_highlight components_data.highlight.sample_data.0 %}
+    <h3>
+      Tableau
+    </h3>
+    <p>
+      Personnalise la couleur de la bordure et du fond.
+    </p>
+    {% dsfr_table components_data.table.sample_data.0 %}
+    <h3>
+      Tag
+    </h3>
+    <p>
+      Personnalise la couleur de la bordure, du fond et de l’icône. Seuls les tags cliquables sont pris en compte.
+    </p>
+    <ul class="fr-tags-group">
+      <li>
+        {% dsfr_tag components_data.tag.sample_data.1 %}
+      </li>
+      <li>
+        {% dsfr_tag components_data.tag.sample_data.3 %}
+      </li>
+    </ul>
+  </div>
+{% endblock content %}
+{% block extra_js %}
+  <script>
+    const colors_list = [
+      "green-tilleul-verveine",
+      "green-bourgeon",
+      "green-emeraude",
+      "green-menthe",
+      "green-archipel",
+      "blue-ecume",
+      "blue-cumulus",
+      "purple-glycine",
+      "pink-macaron",
+      "pink-tuile",
+      "yellow-tournesol",
+      "yellow-moutarde",
+      "orange-terre-battue",
+      "brown-cafe-creme",
+      "brown-caramel",
+      "brown-opera",
+      "beige-gris-galet",
+    ];
+
+
+    function manageColorClasses(base_class, color) {
+      const items = document.getElementsByClassName(base_class);
+
+      let item_color_classes = [];
+      for (let c of colors_list) {
+        item_color_classes.push(base_class + "--" + c);
+      }
+
+      for (const item of items) {
+        item.classList.remove(...item_color_classes)
+
+        if (color !== "") {
+          item.classList.add(base_class + "--" + color);
+        }
+      }
+    }
+
+
+    document.getElementById('id_color').addEventListener('input', function (event) {
+      manageColorClasses("fr-quote", event.target.value);
+      manageColorClasses("fr-callout", event.target.value);
+      manageColorClasses("fr-highlight", event.target.value);
+      manageColorClasses("fr-table", event.target.value);
+      manageColorClasses("fr-tag", event.target.value);
+    }, false);
+  </script>
+{% endblock extra_js %}

--- a/example_app/urls.py
+++ b/example_app/urls.py
@@ -2,6 +2,7 @@ from django_distill import distill_path
 
 from example_app.views import (
     index,
+    resource_colors,
     resource_icons,
     resource_pictograms,
     tags_index,
@@ -64,6 +65,12 @@ urlpatterns = [
         AuthorCreateView.as_view(),
         name="form_formset",
         distill_file="django-dsfr/form/example-formset/index.html",
+    ),
+    distill_path(
+        "resources/colors",
+        resource_colors,
+        name="resource_colors",
+        distill_file="django-dsfr/resources/colors/index.html",
     ),
     distill_path(
         "resources/icons",

--- a/example_app/views.py
+++ b/example_app/views.py
@@ -12,7 +12,7 @@ from django.views.decorators.http import require_safe
 
 from dsfr.utils import generate_summary_items
 
-from example_app.forms import ExampleForm
+from example_app.forms import ColorForm, ExampleForm
 
 from example_app.tag_specifics import (
     ALL_IMPLEMENTED_TAGS,
@@ -350,6 +350,18 @@ def resource_pictograms(request):
     payload["pictograms"] = all_pictos
 
     return render(request, "example_app/page_pictograms.html", payload)
+
+
+@require_safe
+def resource_colors(request):
+    payload = init_payload("Couleurs")
+
+    form = ColorForm()
+
+    payload["form"] = form
+    payload["components_data"] = IMPLEMENTED_TAGS
+
+    return render(request, "example_app/page_colors.html", payload)
 
 
 @require_safe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Sylvain Boissel <sylvain.boissel@beta.gouv.fr>"]
 description = "Integrate the French government Design System into a Django app"
 license = "MIT"
 name = "django-dsfr"
-version = "0.17.1"
+version = "0.17.2"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Web Environment",


### PR DESCRIPTION
## 🎯 Objectif
Certains composants ont des options de couleur d’accentuation permettant de créer des thèmes. Ajout d'une page d'exemple.

## 🔍 Implémentation
- [x] Ajout de constantes avec les différentes catégories de couleurs.
- [x] Ajout d'une page "Couleurs" montrant les exemples d'utilisation.

## 🏕 Amélioration continue
- [x] Correction d’un bug de cache dans les templatetags qui gardaient parfois en mémoire des paramètres venant d'un appel précédent.
- [x] Correction du nom du site dans la balise `title` des pages.

## 🖼️ Images
![Page Couleurs—Django-DSFR](https://github.com/numerique-gouv/django-dsfr/assets/765956/3750d8a6-d798-4b45-98db-f883a1b4b16d)
