### PR TITLE
fix(INSTALL.md): typo in INSTALLED_APPS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ pip install django-dsfr
 ```{ .python }
 INSTALLED_APPS = [
     ...
-    "widget_tweaks"
+    "widget_tweaks",
     "dsfr",
     <votre_app>
 ]
@@ -27,7 +27,7 @@ INSTALLED_APPS = [
 ```{ .python }
 INSTALLED_APPS = [
     ...
-    "widget_tweaks"
+    "widget_tweaks",
     "dsfr",
     "django.forms",
     <votre_app>


### PR DESCRIPTION
## 🎯 Objectif

Corrige l'issue #118
Il manque une virgule pour séparer `"widget_tweaks"` et `"dsfr"`.

C'est un bugfix qui évite l'erreur
`ModuleNotFoundError: No module named 'widget_tweaksdsfr'`