### PR TITLE
Retrait des ":" dans les libellés de champ.

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
@@ -1,5 +1,5 @@
 {% load widget_tweaks dsfr_tags %}
-<div class="fr-checkbox-group{% if field.errors %} fr-checkbox-group--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %}">
+<div class="fr-checkbox-group{% if field.errors %} fr-checkbox-group--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %} fr-mb-2w">
   {% if field.errors %}
     {% with aria_describedby="aria-describedby:"|add:field.auto_id|add:"-desc-error" %}
       {{ field|dsfr_input_class_attr|attr:"type:checkbox"|attr:aria_describedby }}

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -108,6 +108,7 @@ def generate_summary_items(sections_names: list) -> list:
 
 def dsfr_input_class_attr(bf: BoundField):
     if not bf.is_hidden and "class" not in bf.field.widget.attrs:
+        bf.field.label_suffix = ""
         if isinstance(bf.field.widget, (widgets.Select, widgets.SelectMultiple)):
             bf.field.widget.attrs["class"] = "fr-select"
             bf.field.widget.group_class = "fr-select-group"


### PR DESCRIPTION
## 🎯 Objectif

Comme signalé dans #124, les libellés des cases à cocher simples sont terminées par un ":" alors que la case est avant le libellé.

Après vérification de la documentation du DSFR, aucun libellé de champ de formulaire ne devrait avoir de ":", je vais donc également les retirer sur les cases à cocher multiples (les autres champs n'ont déjà pas ce suffixe)

## 🔍 Implémentation
- [x] Retrait du suffixe ":" sur les champs de formulaire 

## 🏕 Amélioration continue
- [x] Ajustement de la marge inférieure des champs de formulaire simples
