### PR TITLE
Ajout d'un bloc breadcrumb au template base.html

### DIFF
--- a/dsfr/context_processors.py
+++ b/dsfr/context_processors.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from dsfr.models import DsfrConfig
 from django.utils.translation import get_language
 
@@ -11,5 +10,4 @@ def site_config(request):
     if not config:
         config = DsfrConfig.objects.first()
 
-    # Add an extra parameter to check if the site is in DEBUG mode
-    return {"SITE_CONFIG": config, "DEBUG": settings.DEBUG}
+    return {"SITE_CONFIG": config}

--- a/dsfr/templates/dsfr/base.html
+++ b/dsfr/templates/dsfr/base.html
@@ -43,7 +43,9 @@
     {% endif %}
 
     <div class="fr-container fr-mt-4w fr-mb-6w">
-      {% dsfr_breadcrumb %}
+      {% block breadcrumb %}
+        {% dsfr_breadcrumb %}
+      {% endblock breadcrumb %}
       <main id="content" role="main">
         {% block content %}
         {% endblock content %}

--- a/example_app/templates/example_app/blocks/header.html
+++ b/example_app/templates/example_app/blocks/header.html
@@ -8,7 +8,7 @@
       {% translate "Display settings" %}
     </button>
   </li>
-  {% if DEBUG %}
+  {% if "127.0.0.1" in request.get_host %}
     <li>
       {% include "example_app/blocks/language_selector.html" %}
     </li>

--- a/example_app/templates/example_app/index.html
+++ b/example_app/templates/example_app/index.html
@@ -1,5 +1,6 @@
 {% extends "example_app/base.html" %}
 {% load static dsfr_tags %}
+
 {% block extra_css %}
   <style nonce="{{ request.csp_nonce }}">
 .code_sample {
@@ -8,6 +9,10 @@
 }
   </style>
 {% endblock extra_css %}
+
+{% block breadcrumb %}
+{% endblock breadcrumb %}
+
 {% block content %}
   <h1>
     Django-DSFR


### PR DESCRIPTION
## 🎯 Objectif
Permettre de configurer le fil d'Ariane sur le template d'une page donnée.

## 🔍 Implémentation
- [x] Ajout d'un bloc `breadcrumb` sur le fil d'Ariane de base.html

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue
- [x] Changement de la façon dont on vérifie comment le sélecteur de langue est appelé sur l'app d'exemple
