### PR TITLE
Ajoute la possibilité d'utiliser un autre formulaire que le `form` présent dans le contexte

### DIFF
--- a/doc/forms.md
+++ b/doc/forms.md
@@ -52,3 +52,19 @@ def __init__(self, *args, **kwargs):
     super().__init__(*args, **kwargs)
     self.fields["password"].widget.attrs["class"] += " my custom class"
 ```
+
+## Utilisation avec les `Formsets`
+
+La balise `{% dsfr_form %}` prend un paramètre optionnel `form` qui permet de surcharger le formulaire à rendre, ce qui 
+est pratique lors de l'utilisation de `Formsets` :
+
+```{ .django }
+<form method="post">
+    {{ formset.management_form }}
+    <table>
+        {% for subform in formset %}
+        {{ dsfr_form subform }}
+        {% endfor %}
+    </table>
+</form>
+```

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1488,17 +1488,23 @@ def dsfr_django_messages(
 
 
 @register.inclusion_tag("dsfr/form_snippet.html", takes_context=True)
-def dsfr_form(context) -> dict:
+def dsfr_form(context: Context, form=None) -> dict:
     """
     Returns the HTML for a form snippet
+    
+    ```python
+    data_dict = {
+        "form": an optionnal form to render instead of the form already present in context
+    }
+    ```
 
     **Tag name**:
         dsfr_form
 
     **Usage**:
         `{% dsfr_form %}`
-    """
-    return context
+    """  # noqa
+    return context.update({"form": form}) if form else context
 
 
 @register.inclusion_tag("dsfr/form_field_snippets/field_snippet.html")

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.test import SimpleTestCase
 from django.template import Context, Template
 from unittest.mock import MagicMock
@@ -11,6 +12,7 @@ from dsfr.checksums import (
     INTEGRITY_JS_MODULE,
     INTEGRITY_JS_NOMODULE,
 )
+from dsfr.forms import DsfrBaseForm
 from dsfr.templatetags.dsfr_tags import concatenate, hyphenate
 
 
@@ -477,6 +479,40 @@ class DsfrConsentTagTest(SimpleTestCase):
                 </li>
             </ul>
             </div>
+            """,
+            rendered_template,
+        )
+
+
+class DsfrFormTagTest(SimpleTestCase):
+    class TestForm(DsfrBaseForm):
+        test = forms.CharField(label="Ceci est un test")
+
+    class TestForm2(DsfrBaseForm):
+        test = forms.CharField(label="Ceci est un autre test")
+
+    context = Context({"form": TestForm(), "form2": TestForm2()})
+
+    def test_dsfr_form_renders(self):
+        rendered_template = Template(
+            "{% load dsfr_tags %} {% dsfr_form %}"
+        ).render(self.context)
+        self.assertInHTML(
+            """
+            <label for="id_test" class="fr-label">Ceci est un test*</label>
+            <input type="text" name="test" class="fr-input" required id="id_test">
+            """,
+            rendered_template,
+        )
+
+    def test_dsfr_form_renders_with_form_override(self):
+        rendered_template = Template(
+            "{% load dsfr_tags %} {% dsfr_form form2 %}"
+        ).render(self.context)
+        self.assertInHTML(
+            """
+            <label for="id_test" class="fr-label">Ceci est un autre test*</label>
+            <input type="text" name="test" class="fr-input" required id="id_test">
             """,
             rendered_template,
         )


### PR DESCRIPTION
## 🎯 Objectif

Nouvelle fonctionnalité : ajoute la possibilité d'utiliser un autre formulaire que le `form` présent dans le contexte.