### PR TITLE
Pris en charge du rendu des champs cachés.

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
@@ -1,5 +1,7 @@
 {% load widget_tweaks %}
-{% if field|widget_type == "checkboxinput" %}
+{% if field.is_hidden %}
+  {{ field.as_hidden }}
+{% elif field|widget_type == "checkboxinput" %}
   {% include "dsfr/form_field_snippets/checkbox_snippet.html" %}
 {% elif field|widget_type == "checkboxselectmultiple" %}
   {% include "dsfr/form_field_snippets/checkboxselectmultiple_snippet.html" %}


### PR DESCRIPTION
## 🎯 Objectif

Utile pour faire :

```python
{% for field in form %}
  {% dsfr_form_field field %}
{% endfor %}