### PR TITLE
add custom footer license block

### DIFF
--- a/dsfr/templates/dsfr/footer.html
+++ b/dsfr/templates/dsfr/footer.html
@@ -117,6 +117,8 @@
              target="_blank"
              rel="noopener external"
              title="{{ etalab_license|capfirst }} - {{ new_window_label }}">{{ etalab_license }}</a>
+             {% block custom-footer-license %}
+             {% endblock custom-footer-license %}
         </p>
       </div>
     </div>

--- a/dsfr/templates/dsfr/footer.html
+++ b/dsfr/templates/dsfr/footer.html
@@ -117,8 +117,8 @@
              target="_blank"
              rel="noopener external"
              title="{{ etalab_license|capfirst }} - {{ new_window_label }}">{{ etalab_license }}</a>
-             {% block custom-footer-license %}
-             {% endblock custom-footer-license %}
+             {% block footer_bottom_extra %}
+             {% endblock footer_bottom_extra %}
         </p>
       </div>
     </div>


### PR DESCRIPTION
Permet d'ajouter du texte juste apres la déclaration de licence etalab 2.0 , dans le footer 
