### PR TITLE
Ajout des boutons radio riches

### DIFF
--- a/doc/forms.md
+++ b/doc/forms.md
@@ -58,3 +58,329 @@ def __init__(self, *args, **kwargs):
 La balise `{% dsfr_form %}` est maintenant dépréciée et sera retirée à la fin de l’année 2024.
 
 Il faut donc remplacer les instances de `{% dsfr_form %}` par ``{{ form }}`` et `{% dsfr_form my_custom_form %}` par `{{ my_custom_form }}`.
+
+## Composants
+
+### `dsfr.enums.ExtendedChoices` {: #extended-choices }
+
+Extension de [Django's `models.Choices`][1] pour supporter l'ajout d'attributs
+arbitraires aux enums en utilisant un dictionnaire.
+
+Exemple d'utilisation :
+
+```python
+from dsfr.enums import ExtendedChoices
+
+class TemperatureChoices(ExtendedChoices):
+  COLD = {
+    "value": "COLD",
+    "label": "Cold",
+    "temperature": "<12°c"
+  }
+  OK = {
+    "value": "OK",
+    "label": "ok",
+    "temperature": ">=12°c,<25°c"
+  }
+  HOT = {
+    "value": "HOT",
+    "label": "Hot!",
+    "temperature": ">=25°c"
+  }
+
+TemperatureChoices.OK.temperature == ">=12°c,<25°c"
+```
+
+Dans l'exemple précédent, en plus de `TemperatureChoices.<enum instance>.value`,
+`TemperatureChoices.<enum instance>.label` et
+`TemperatureChoices.<enum instance>.name`, `ExtendedChoices` ajoute une propriété
+`temperature` pour chaque instance de instance d'enum.
+
+Exemple : `TemperatureChoices.<enum instance>.temperature`.
+
+Notez que `"value"` est la seule clé obligatoire dans le dictionnaire. Lorsqu'un
+dictionnaire ne contient que `« value »`, les exemples suivants sont équivalents :
+
+```python
+from django.db import models
+from dsfr.enums import ExtendedChoices
+
+class TemperatureChoices(models.Choices):
+    COLD = "COLD"
+
+class TemperatureChoices(ExtendedChoices):
+    COLD = {"value": "COLD"}
+```
+
+Voir [cette section sur la façon de fournir des valeurs par défaut pour des attributs supplémentaires](#default-values)
+
+#### Utilisation avec `enum.auto()`
+
+`ExtendedChoices` supporte l'utilisation de [`enum.auto()`][2] :
+
+```python
+from enum import auto
+from django.db import models
+from dsfr.enums import ExtendedChoices
+
+class TemperatureChoices(ExtendedChoices, models.TextChoices):
+  COLD = {
+    "value": auto(),
+    "label": "Cold",
+    "temperature": "<12°c"
+  }
+  OK = {
+    "value": auto(),
+    "label": "ok",
+    "temperature": ">=12°c,<25°c"
+  }
+  HOT = {
+    "value": auto(),
+    "label": "Hot!",
+    "temperature": ">=25°c"
+  }
+```
+
+`ExtendedChoices` peut être utilisé en combinaison `django.db.models.TextChoices`
+ou `django.db.models.IntegerChoices` pour calculer automatiquement l'attribut
+`value` avec `enum.auto()` ou peut définir une méthode `_generate_next_value_` pour
+fournir la valeur (voir [[2]][2]) :
+
+```python
+from enum import auto
+from dsfr.enums import ExtendedChoices
+
+class TemperatureChoices(ExtendedChoices):
+  COLD = {
+    "value": auto(),
+    "label": "Cold",
+    "temperature": "<12°c"
+  }
+  OK = {
+    "value": auto(),
+    "label": "ok",
+    "temperature": ">=12°c,<25°c"
+  }
+  HOT = {
+    "value": auto(),
+    "label": "Hot!",
+    "temperature": ">=25°c"
+  }
+
+  def _generate_next_value_(name, start, count, last_values):
+      return f"{name}: {count}"
+```
+
+#### Fournir des valeurs par défaut aux attributs supplémentaires {: #default-values}
+
+Il peut arriver que vous souhaitiez fournir dynamiquement des valeurs pour un
+attribut supplémentaire. Si vous ne spécifiez pas de valeur pour un attribut
+supplémentaire lors de la déclaration de l'enum, vous pouvez la fournir
+dynamiquement avec la méthode `dynamic_attribute_value` :
+
+```python
+from enum import auto
+from django.conf import settings
+from django.db import models
+from dsfr.enums import ExtendedChoices
+class TemperatureChoices(ExtendedChoices, models.IntegerChoices):
+    COLD = {
+        "value": auto(),
+        "temperature": {"lorem": "ipsum 1"},
+    }
+    OK = auto()
+
+    def dynamic_attribute_value(self, name):
+      if name == "temperature":
+        return settings.TEMPERATURES[self.value]
+      else:
+        return -1
+```
+
+Dans l'exemple précédent, la valeur de `temperature` n'est pas spécifiée pour
+`TemperatureChoices.OK`. Accéder à la propriété `TemperatureChoices.OK.temperature`
+appellera `TemperatureChoices.OK.dynamic_attribute_value("temperature")` pour .
+
+#### Utilisation avancée
+
+Par défaut, lorsque vous spécifiez des attibuts supplémentaires, `ExtendedChoices`
+stocke cette valeur dans un membre de l'instance. Le nom de se membre correspond
+au nom de l'attribut spécifié précédé de `__`. Exemple :
+
+```python
+from enum import auto
+from dsfr.enums import ExtendedChoices
+
+class TemperatureChoices(ExtendedChoices):
+  COLD = {
+    "value": auto(),
+    "label": "Cold",
+    "temperature": "<12°c"
+  }
+  OK = {
+    "value": auto(),
+    "label": "ok",
+    "temperature": ">=12°c,<25°c"
+  }
+  HOT = {
+    "value": auto(),
+    "label": "Hot!",
+    "temperature": ">=25°c"
+  }
+
+TemperatureChoices.OK.__temperature == TemperatureChoices.OK.temperature
+```
+
+Si, pour quelque raison que ce soit, vous souhaitez utiliser un autre nom pour
+l'instance qui stocke la valeur, vous pouvez déclarer une méthode statique
+`private_variable_name` :
+
+```python
+from enum import auto
+from dsfr.enums import ExtendedChoices
+
+class TemperatureChoices(ExtendedChoices):
+  COLD = {
+    "value": auto(),
+    "label": "Cold",
+    "temperature": "<12°c"
+  }
+  OK = {
+    "value": auto(),
+    "label": "ok",
+    "temperature": ">=12°c,<25°c"
+  }
+  HOT = {
+    "value": auto(),
+    "label": "Hot!",
+    "temperature": ">=25°c"
+  }
+
+  @staticmethod
+  def private_variable_name(name):
+    return f"m_{name}"
+
+TemperatureChoices.OK.m_temperature == TemperatureChoices.OK.temperature
+```
+
+[1]: https://docs.djangoproject.com/en/5.1/ref/models/fields/#enumeration-types
+[2]: https://docs.python.org/3/library/enum.html#enum.auto
+
+### `dsfr.enums.RichRadioButtonChoices` {: #rich-choices }
+
+Version spécialisée de [`RichRadioButtonChoices`](#extended-choices) à utiliser avec
+`dsfr.widgets.RichRadioSelect`. Cette version déclare en plus les propriétés
+`pictogram`, `pictogram_alt` et `html_label` :
+
+```python
+from enum import auto
+from django.db.models import IntegerChoices
+from dsfr.utils import lazy_static
+from dsfr.enums import RichRadioButtonChoices
+
+class ExampleRichChoices(IntegerChoices, RichRadioButtonChoices):
+  ITEM_1 = {
+      "value": auto(),
+      "label": "Item 1",
+      "html_label": "<strong>Item 1</strong>",
+      "pictogram": lazy_static("img/placeholder.1x1.png"),
+  }
+  ITEM_2 = {
+      "value": auto(),
+      "label": "Item 2",
+      "html_label": "<strong>Item 2</strong>",
+      "pictogram": lazy_static("img/placeholder.1x1.png"),
+  }
+  ITEM_3 = {
+      "value": auto(),
+      "label": "Item 3",
+      "html_label": "<strong>Item 3</strong>",
+      "pictogram": lazy_static("img/placeholder.1x1.png"),
+  }
+```
+
+Voir [`dsfr.widgets.RichRadioSelect`](#rich-radio-select) pour plus de détails.
+
+### `dsfr.widgets.RichRadioSelect` {: #rich-radio-select }
+
+Widget permettant de produire des boutons radio riches. Ce widget fonctionne avec
+[`dsfr.enums.ExtendedChoices`](#rich-choices).
+
+`RichRadioSelect.__init__` prend obligatoirement un argument `rich_choices` de type
+`RichRadioButtonChoices`.
+
+Utilisation :
+
+```python
+from enum import auto
+from django.db.models import IntegerChoices
+from django import forms
+from dsfr.forms import DsfrBaseForm
+from dsfr.utils import lazy_static
+from dsfr.enums import RichRadioButtonChoices
+from dsfr.widgets import RichRadioSelect
+
+class ExampleRichChoices(RichRadioButtonChoices, IntegerChoices):
+    ITEM_1 = {
+        "value": auto(),
+        "label": "Item 1",
+        "html_label": "<strong>Item 1</strong>",
+        "pictogram": lazy_static("img/placeholder.1x1.png"),
+    }
+    ITEM_2 = {
+        "value": auto(),
+        "label": "Item 2",
+        "html_label": "<strong>Item 2</strong>",
+        "pictogram": lazy_static("img/placeholder.1x1.png"),
+    }
+    ITEM_3 = {
+        "value": auto(),
+        "label": "Item 3",
+        "html_label": "<strong>Item 3</strong>",
+        "pictogram": lazy_static("img/placeholder.1x1.png"),
+    }
+
+class ExampleForm(DsfrBaseForm):
+    sample_rich_radio = forms.ChoiceField(
+        label="Cases à cocher",
+        required=False,
+        choices=ExampleRichChoices.choices,
+        help_text="Exemple de boutons radios riches",
+        widget=RichRadioSelect(rich_choices=ExampleRichChoices),
+    )
+```
+
+#### `html_label`
+
+L'attribut `html_label` peut-être utilisé pour déclarer du HTML à insérer dans
+`<label>`. Le code est automatiquement marqué sûr avec
+[`django.utils.safestring.mark_safe`][1] et ne produira pas de
+[problème d'échappement du HTML][2] dans vos templates.
+
+Si `html_label` n'est pas déclaré par un membre de l'enum, la propriété `html_label`
+renvoie la valeur de la propriété `label` à la place.
+
+#### `pictogram`
+
+L'attribut `pictogram` peut être utilisé pour spécifier le pictogramme du bouton
+radio riche. Il peut être utilisé en combinaison avec [`dsfr.utils.lazy_static`](#lazy-static)
+pour charger une ressource statique.
+
+#### `pictogram_alt`
+
+L'attribut `pictogram_alt` définit la valeur à mettre dans l'attribut `alt` de la
+balise `<img>` utilisée dans le bouton radio riche. S'il n'est pas déclaré par
+l'enum, `RichRadioSelect` ajoute un `alt=""`.
+
+[1]: https://docs.djangoproject.com/en/5.1/ref/utils/#django.utils.safestring.mark_safe
+[2]: https://docs.djangoproject.com/en/5.1/ref/templates/language/#automatic-html-escaping
+
+### `dsfr.utils.lazy_static` {: #lazy-static }
+
+Équivalent du tag Django `{% static %}` à utiliser dans le code. Exemple :
+
+```python
+from dsfr.utils import lazy_static
+
+lazy_static("img/logo.png")
+```

--- a/dsfr/enums.py
+++ b/dsfr/enums.py
@@ -1,0 +1,418 @@
+from django import VERSION
+from django.db import models
+from django.utils.safestring import mark_safe
+from django.utils.version import PY311
+
+if PY311:
+    from enum import property as enum_property
+else:
+    from types import DynamicClassAttribute as enum_property
+
+if VERSION >= (5, 0):
+    from django.db.models.enums import ChoicesType
+else:
+    from django.db.models.enums import ChoicesMeta as ChoicesType
+
+__all__ = ["ExtendedChoices", "RichRadioButtonChoices"]
+
+
+def _is_dunder(name):
+    """Returns True if a __dunder__ name, False otherwise."""
+    return (
+        len(name) > 4
+        and name[:2] == name[-2:] == "__"
+        and name[2] != "_"
+        and name[-3] != "_"
+    )
+
+
+def _is_sunder(name):
+    """Returns True if a _sunder_ name, False otherwise."""
+    return (
+        len(name) > 2
+        and name[0] == name[-1] == "_"
+        and name[1:2] != "_"
+        and name[-2:-1] != "_"
+    )
+
+
+class _ExtendedChoicesType(ChoicesType):
+    @classmethod
+    def __prepare__(metacls, cls, bases, **kwds):
+        classdict = super().__prepare__(cls, bases, **kwds)
+
+        class _EnumDict(classdict.__class__):
+            def __init__(self, old_classdict):
+                super().__init__()
+                self._additional_attributes = {}
+                # Copy absent old_classdict members into self
+                for member_name, member_value in old_classdict.__dict__.items():
+                    self.__dict__.setdefault(member_name, member_value)
+
+                # Copy dict content
+                self.update(old_classdict)
+
+            def __setitem__(self, member, value):
+                """Allows to handle declaring enum members as dicts"""
+                if not PY311 and isinstance(value, (list, tuple)):
+                    # Prior to Python 3.11, EnumDict does not interpret auto() when
+                    # wrapped in a tuple so we need to set the value alone a first time
+                    # before wrapping it in a tuple.
+                    if len(value) == 1:
+                        return super().__setitem__(member, value[0])
+
+                    if len(value) == 2:
+                        value, label = value
+                    else:
+                        *value, label = value
+
+                    super().__setitem__(member, value)
+                    dict.__setitem__(self, member, (self[member], label))
+                    return
+
+                if not isinstance(value, dict):
+                    return super().__setitem__(member, value)
+
+                if "value" not in value:
+                    raise ValueError(
+                        "enum value for {member} should contain member 'value' "
+                        "when using a dict as value; got {member} = {value}".format(
+                            member=member, value=repr(value)
+                        )
+                    )
+
+                if PY311:
+                    if "label" in value:
+                        super().__setitem__(
+                            member, (value.pop("value"), value.pop("label"))
+                        )
+                    else:
+                        super().__setitem__(member, value.pop("value"))
+                else:
+                    # Prior to Python 3.11, EnumDict does not interpret auto() when
+                    # wrapped in a tuple so we need to set the value alone a first time
+                    # before wrapping it in a tuple.
+                    super().__setitem__(member, value.pop("value"))
+                    if "label" in value:
+                        dict.__setitem__(
+                            self, member, (self[member], value.pop("label"))
+                        )
+
+                for attr_name, attr_value in value.items():
+                    if _is_sunder(attr_name) or _is_dunder(attr_name):
+                        raise ValueError(
+                            (
+                                "enum value for {member} contains key {key}. "
+                                "Names surrounded with single or double underscores are "
+                                "not authorized as dict values"
+                            ).format(member=member, key=attr_name)
+                        )
+                    self._additional_attributes.setdefault(attr_name, {})
+                    self._additional_attributes[attr_name][member] = attr_value
+
+        return _EnumDict(classdict)
+
+    def __new__(metacls, classname, bases, classdict, **kwds):
+        cls = super().__new__(metacls, classname, bases, classdict, **kwds)
+        cls._additional_attributes = list(classdict._additional_attributes.keys())
+
+        def instance_property_getter(name):
+            @enum_property
+            def _instance_property_getter(enum_item):
+                private_name = enum_item.private_variable_name(name)
+                if hasattr(enum_item, private_name):
+                    return getattr(enum_item, private_name)
+                elif hasattr(enum_item, "dynamic_attribute_value"):
+                    return enum_item.dynamic_attribute_value(name)
+                else:
+                    raise AttributeError(
+                        (
+                            "{}.{} does not contain key '{}'. Please add key or "
+                            "implement a 'dynamic_attribute_value(self, name)' method "
+                            "in you enum to provide a value"
+                        ).format(cls.__name__, instance.name, name)
+                    )
+
+            return _instance_property_getter
+
+        for instance in cls:
+            for attr_name, attr_value in classdict._additional_attributes.items():
+                if hasattr(instance, cls.private_variable_name(attr_name)):
+                    raise ValueError(
+                        (
+                            "Can't set '{}' on {}.{}; instance already has a private "
+                            "'{}' attribute; please choose a different name or remove "
+                            "from the member value"
+                        ).format(
+                            attr_name,
+                            cls.__name__,
+                            instance.name,
+                            cls.private_variable_name(attr_name),
+                        )
+                    )
+
+                if instance.name in attr_value:
+                    setattr(
+                        instance,
+                        cls.private_variable_name(attr_name),
+                        attr_value[instance.name],
+                    )
+
+                if not hasattr(instance, attr_name):
+                    setattr(cls, attr_name, instance_property_getter(attr_name))
+
+        return cls
+
+    @property
+    def additional_attributes(cls):
+        """Enum additionnal attributes that were set from dict"""
+        return cls._additional_attributes
+
+
+class ExtendedChoices(models.Choices, metaclass=_ExtendedChoicesType):
+    """
+    Extension de [Django's `models.Choices`][1] pour supporter l'ajout d'attributs
+    arbitraires aux enums en utilisant un dictionnaire.
+
+    Exemple d'utilisation :
+
+    ```python
+    >>> class TemperatureChoices(ExtendedChoices):
+    ...   COLD = {
+    ...     "value": "COLD",
+    ...     "label": "Cold",
+    ...     "temperature": "<12°c"
+    ...   }
+    ...   OK = {
+    ...     "value": "OK",
+    ...     "label": "ok",
+    ...     "temperature": ">=12°c,<25°c"
+    ...   }
+    ...   HOT = {
+    ...     "value": "HOT",
+    ...     "label": "Hot!",
+    ...     "temperature": ">=25°c"
+    ...   }
+    >>> TemperatureChoices.OK.temperature
+    ">=12°c,<25°c"
+    ```
+
+    Dans l'exemple précédent, en plus de `TemperatureChoices.<enum instance>.value`,
+    `TemperatureChoices.<enum instance>.label` et
+    `TemperatureChoices.<enum instance>.name`, `ExtendedChoices` ajoute une propriété
+    `temperature` pour chaque instance de instance d'enum.
+
+    Exemple : `TemperatureChoices.<enum instance>.temperature`.
+
+    Notez que `"value"` est la seule clé obligatoire dans le dictionnaire. Lorsqu'un
+    dictionnaire ne contient que `« value »`, les exemples suivants sont équivalents :
+
+    ```python
+    >>> from django.db import models
+    >>> class TemperatureChoices(models.Choices):
+    ...     COLD = "COLD"
+
+    >>> class TemperatureChoices(ExtendedChoices):
+    ...     COLD = {"value": "COLD"}
+    ```
+
+    Voir [cette section sur la façon de fournir des valeurs par défaut pour des attributs supplémentaires](#default-values)
+
+    ## Utilisation avec `enum.auto()`
+
+    `ExtendedChoices` supporte l'utilisation de [`enum.auto()`][2] :
+
+    ```python
+    >>> from enum import auto
+    >>> from django.db import models
+    >>> class TemperatureChoices(ExtendedChoices, models.TextChoices):
+    ...   COLD = {
+    ...     "value": auto(),
+    ...     "label": "Cold",
+    ...     "temperature": "<12°c"
+    ...   }
+    ...   OK = {
+    ...     "value": auto(),
+    ...     "label": "ok",
+    ...     "temperature": ">=12°c,<25°c"
+    ...   }
+    ...   HOT = {
+    ...     "value": auto(),
+    ...     "label": "Hot!",
+    ...     "temperature": ">=25°c"
+    ...   }
+    ```
+
+    `ExtendedChoices` peut être utilisé en combinaison `django.db.models.TextChoices`
+    ou `django.db.models.IntegerChoices` pour calculer automatiquement l'attribut
+    `value` avec `enum.auto()` ou peut définir une méthode `_generate_next_value_` pour
+    fournir la valeur (voir [[2]][2]) :
+
+    ```python
+    >>> from enum import auto
+    >>> class TemperatureChoices(ExtendedChoices):
+    ...   COLD = {
+    ...     "value": auto(),
+    ...     "label": "Cold",
+    ...     "temperature": "<12°c"
+    ...   }
+    ...   OK = {
+    ...     "value": auto(),
+    ...     "label": "ok",
+    ...     "temperature": ">=12°c,<25°c"
+    ...   }
+    ...   HOT = {
+    ...     "value": auto(),
+    ...     "label": "Hot!",
+    ...     "temperature": ">=25°c"
+    ...   }
+    ...
+    ...   def _generate_next_value_(name, start, count, last_values):
+    ...       return f"{name}: {count}"
+    ```
+
+    ## Fournir des valeurs par défaut aux attributs supplémentaires {: #default-values}
+
+    Il peut arriver que vous souhaitiez fournir dynamiquement des valeurs pour un
+    attribut supplémentaire. Si vous ne spécifiez pas de valeur pour un attribut
+    supplémentaire lors de la déclaration de l'enum, vous pouvez la fournir
+    dynamiquement avec la méthode `dynamic_attribute_value` :
+
+    ```python
+    >>> from enum import auto
+    >>> from django.conf import settings
+    >>> from django.db import models
+    >>> class TemperatureChoices(ExtendedChoices, models.IntegerChoices):
+    ... COLD = {
+    ...     "value": auto(),
+    ...     "temperature": {"lorem": "ipsum 1"},
+    ... }
+    ... OK = auto()
+    ...
+    ... def dynamic_attribute_value(self, name):
+    ...   if name == "temperature":
+    ...     return settings.TEMPERATURES[self.value]
+    ...   else:
+    ...     return -1
+    ```
+
+    Dans l'exemple précédent, la valeur de `temperature` n'est pas spécifiée pour
+    `TemperatureChoices.OK`. Accéder à la propriété `TemperatureChoices.OK.temperature`
+    appellera `TemperatureChoices.OK.dynamic_attribute_value("temperature")` pour .
+
+    ## Utilisation avancée
+
+    Par défaut, lorsque vous spécifiez des attibuts supplémentaires, `ExtendedChoices`
+    stocke cette valeur dans un membre de l'instance. Le nom de se membre correspond
+    au nom de l'attribut spécifié précédé de `__`. Exemple :
+
+    ```python
+    >>> from enum import auto
+    >>> class TemperatureChoices(ExtendedChoices):
+    ...   COLD = {
+    ...     "value": auto(),
+    ...     "label": "Cold",
+    ...     "temperature": "<12°c"
+    ...   }
+    ...   OK = {
+    ...     "value": auto(),
+    ...     "label": "ok",
+    ...     "temperature": ">=12°c,<25°c"
+    ...   }
+    ...   HOT = {
+    ...     "value": auto(),
+    ...     "label": "Hot!",
+    ...     "temperature": ">=25°c"
+    ...   }
+
+    >>> TemperatureChoices.OK.__temperature == TemperatureChoices.OK.temperature
+    ```
+
+    Si, pour quelque raison que ce soit, vous souhaitez utiliser un autre nom pour
+    l'instance qui stocke la valeur, vous pouvez déclarer une méthode statique
+    `private_variable_name` :
+
+    ```python
+    >>> from enum import auto
+    >>> class TemperatureChoices(ExtendedChoices):
+    ...   COLD = {
+    ...     "value": auto(),
+    ...     "label": "Cold",
+    ...     "temperature": "<12°c"
+    ...   }
+    ...   OK = {
+    ...     "value": auto(),
+    ...     "label": "ok",
+    ...     "temperature": ">=12°c,<25°c"
+    ...   }
+    ...   HOT = {
+    ...     "value": auto(),
+    ...     "label": "Hot!",
+    ...     "temperature": ">=25°c"
+    ...   }
+    ...
+    ...   @staticmethod
+    ...   def private_variable_name(name):
+    ...     return f"m_{name}"
+
+    >>> TemperatureChoices.OK.m_temperature == TemperatureChoices.OK.temperature
+    ```
+
+    [1]: https://docs.djangoproject.com/en/5.1/ref/models/fields/#enumeration-types
+    [2]: https://docs.python.org/3/library/enum.html#enum.auto
+    """
+
+    @staticmethod
+    def private_variable_name(name):
+        return f"__{name}"
+
+
+class RichRadioButtonChoices(ExtendedChoices):
+    """
+    Version spécialisée de `ExtendedChoices` à utiliser avec
+    `dsfr.widgets.RichRadioSelect`. Cette version déclare en plus les propriétés
+    `pictogram`, `pictogram_alt` et `html_label` :
+
+    ```python
+    >>> from enum import auto
+    >>> from django.db.models import IntegerChoices
+    >>> from dsfr.utils import lazy_static
+    >>> class ExampleRichChoices(IntegerChoices, RichRadioButtonChoices):
+    ...   ITEM_1 = {
+    ...       "value": auto(),
+    ...       "label": "Item 1",
+    ...       "html_label": "<strong>Item 1</strong>",
+    ...       "pictogram": lazy_static("img/placeholder.1x1.png"),
+    ...   }
+    ...   ITEM_2 = {
+    ...       "value": auto(),
+    ...       "label": "Item 2",
+    ...       "html_label": "<strong>Item 2</strong>",
+    ...       "pictogram": lazy_static("img/placeholder.1x1.png"),
+    ...   }
+    ...   ITEM_3 = {
+    ...       "value": auto(),
+    ...       "label": "Item 3",
+    ...       "html_label": "<strong>Item 3</strong>",
+    ...       "pictogram": lazy_static("img/placeholder.1x1.png"),
+    ...   }
+    ```
+
+    Voir `dsfr.widgets.RichRadioSelect` pour plus de détails.
+    """
+
+    @enum_property
+    def pictogram(self):
+        return getattr(self, self.private_variable_name("pictogram"), "")
+
+    @enum_property
+    def pictogram_alt(self):
+        return getattr(self, self.private_variable_name("pictogram_alt"), None)
+
+    @enum_property
+    def html_label(self):
+        return (
+            mark_safe(getattr(self, self.private_variable_name("html_label")))  # nosec
+            if hasattr(self, self.private_variable_name("html_label"))
+            else self.label
+        )

--- a/dsfr/templates/dsfr/widgets/rich_radio.html
+++ b/dsfr/templates/dsfr/widgets/rich_radio.html
@@ -1,0 +1,21 @@
+{% with id=widget.attrs.id %}
+  <fieldset {% if id %}id="{{ id }}"{% endif %}
+            class="fr-fieldset{% if widget.attrs.class %} {{ widget.attrs.class }}{% endif %}"
+            {% if id %}aria-labelledby="{{ id }}-legend"{% endif %}>
+    {% for group, options, index in widget.optgroups %}
+      {% if group %}
+        <legend id="{{ group }}-legend"
+                class="fr-fieldset__legend{% if widget.attrs.legend_classes %} {{ widget.attrs.legend_classes }}{% endif %}">
+          {{ group }}
+        </legend>
+        <fieldset aria-labelledby="{{ group }}-legend">
+        {% endif %}
+        {% for option in options %}
+          {% include option.template_name with widget=option %}
+        {% endfor %}
+        {% if group %}
+        </fieldset>
+      {% endif %}
+    {% endfor %}
+  </fieldset>
+{% endwith %}

--- a/dsfr/templates/dsfr/widgets/rich_radio_option.html
+++ b/dsfr/templates/dsfr/widgets/rich_radio_option.html
@@ -1,0 +1,18 @@
+<div class="fr-fieldset__element{% if widget.inline %} fr-fieldset__element--inline{% endif %}">
+  <div class="fr-radio-group fr-radio-rich">
+    <input value="{{ widget.value }}"
+           type="{{ widget.type }}"
+           id="{{ widget.attrs.id }}"
+           name="{{ widget.name }}"
+           {% include "django/forms/widgets/attrs.html" %}>
+    <label class="fr-label" for="{{ widget.attrs.id }}">
+      {{ widget.html_label }}
+    </label>
+    {% if widget.pictogram %}
+      <div class="fr-radio-rich__pictogram">
+        <img src="{{ widget.pictogram }}"
+             {% if widget.pictogram_alt is not None %} alt="{{ widget.pictogram_alt }}"{% endif %} />
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/dsfr/test/test_enums.py
+++ b/dsfr/test/test_enums.py
@@ -1,0 +1,176 @@
+from enum import auto
+from unittest import skipIf
+
+from django.db.models import IntegerChoices
+from django.test import SimpleTestCase
+from django.utils.safestring import mark_safe
+from django.utils.version import PY311
+
+from dsfr.enums import ExtendedChoices
+
+if PY311:
+    from enum import property as enum_property, nonmember
+else:
+    from types import DynamicClassAttribute as enum_property
+
+
+class ExtendedChoicesTestCase(SimpleTestCase):
+    def test_create_dict_enum(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {
+                "value": auto(),
+                "label": "Test 1",
+            }
+            TEST_2 = {
+                "value": auto(),
+                "label": "Test 2",
+            }
+
+        self.assertEqual(
+            {(1, "Test 1"), (2, "Test 2")}, set(TestExtendedChoices.choices)
+        )
+        self.assertEqual({"Test 1", "Test 2"}, set(TestExtendedChoices.labels))
+        self.assertEqual({"TEST_1", "TEST_2"}, set(TestExtendedChoices.names))
+        self.assertEqual({1, 2}, set(TestExtendedChoices.values))
+
+    def test_additional_attributes(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {
+                "value": auto(),
+                "additionnal_attribute_1": {"lorem": "ipsum 1"},
+                "additionnal_attribute_2": mark_safe(
+                    "<strong>Item 1</strong>"
+                ),  # nosec
+            }
+            TEST_2 = {
+                "value": auto(),
+                "additionnal_attribute_1": {"lorem": "ipsum 2"},
+                "additionnal_attribute_2": mark_safe(
+                    "<strong>Item 2</strong>"
+                ),  # nosec
+            }
+
+        self.assertEqual(
+            {"additionnal_attribute_1", "additionnal_attribute_2"},
+            set(TestExtendedChoices.additional_attributes),
+        )
+        self.assertEqual(
+            [{"lorem": "ipsum 1"}, {"lorem": "ipsum 2"}],
+            [it.additionnal_attribute_1 for it in TestExtendedChoices],
+        )
+        self.assertEqual(
+            {"<strong>Item 1</strong>", "<strong>Item 2</strong>"},
+            {it.additionnal_attribute_2 for it in TestExtendedChoices},
+        )
+
+    @skipIf(not PY311, "'enum.nonmember' was added to Python 3.11")
+    def test_nonmember_attributes(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {"value": auto()}
+            TEST_2 = {"value": auto()}
+
+            additional_attribute = nonmember({"lorem": "ipsum 1"})
+
+        self.assertEqual(
+            {(1, "Test 1"), (2, "Test 2")}, set(TestExtendedChoices.choices)
+        )
+
+    def test_absent_value_key_raises_error(self):
+        with self.assertRaises(ValueError) as e:
+
+            class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+                TEST_1 = {"label": "Test 1"}
+                TEST_2 = {"label": "Test 2"}
+
+        self.assertEqual(
+            "enum value for TEST_1 should contain member 'value' "
+            "when using a dict as value; got TEST_1 = {'label': 'Test 1'}",
+            str(e.exception),
+        )
+
+    def test_absent_label_computes_default(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {"value": auto()}
+            TEST_2 = auto(), "Autre label"
+
+        self.assertEqual({"Test 1", "Autre label"}, set(TestExtendedChoices.labels))
+
+    def test_absent_additionnal_key_calls_dynamic_attribute_value_method(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {
+                "value": auto(),
+                "additionnal_attribute": {"lorem": "ipsum 1"},
+            }
+            TEST_2 = auto()
+
+            def dynamic_attribute_value(self, name):
+                if name == "additionnal_attribute":
+                    return {"lorem": "ipsum {}".format(self.value)}
+                else:
+                    return {"lorem": "ipsum x"}
+
+        self.assertEqual(
+            [{"lorem": "ipsum 1"}, {"lorem": "ipsum 2"}],
+            [it.additionnal_attribute for it in TestExtendedChoices],
+        )
+
+    def test_absent_additionnal_key_no_dynamic_attribute_value_method(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {
+                "value": auto(),
+                "additionnal_attribute": {"lorem": "ipsum 1"},
+            }
+            TEST_2 = auto()
+
+        with self.assertRaises(AttributeError) as e:
+            TestExtendedChoices.TEST_2.additionnal_attribute
+
+        self.assertEqual(
+            "TestExtendedChoices.TEST_2 does not contain key 'additionnal_attribute'. "
+            "Please add key or implement a 'dynamic_attribute_value(self, name)' "
+            "method in you enum to provide a value",
+            str(e.exception),
+        )
+
+    def test_uses_overriden_getter(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {
+                "value": auto(),
+                "additionnal_attribute": {"lorem": "ipsum 1"},
+            }
+            TEST_2 = auto()
+
+            @enum_property
+            def additionnal_attribute(self):
+                return "overriden attribute"
+
+        self.assertEqual(
+            ["overriden attribute", "overriden attribute"],
+            [it.additionnal_attribute for it in TestExtendedChoices],
+        )
+
+    def test_uses_additional_attribute_private_name(self):
+        class TestExtendedChoices(ExtendedChoices, IntegerChoices):
+            TEST_1 = {
+                "value": auto(),
+                "additionnal_attribute_1": {"lorem": "ipsum 1"},
+                "additionnal_attribute_2": mark_safe(
+                    "<strong>Item 1</strong>"
+                ),  # nosec
+            }
+            TEST_2 = {
+                "value": auto(),
+                "additionnal_attribute_1": {"lorem": "ipsum 2"},
+                "additionnal_attribute_2": mark_safe(
+                    "<strong>Item 2</strong>"
+                ),  # nosec
+            }
+
+            @staticmethod
+            def private_variable_name(name):
+                return f"m_{name}"
+
+        self.assertEqual(
+            {"<strong>Item 1</strong>", "<strong>Item 2</strong>"},
+            {it.m_additionnal_attribute_2 for it in TestExtendedChoices},
+        )

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -1,5 +1,9 @@
+import functools
+
 from django.forms import BoundField, widgets
 from django.core.paginator import Page
+from django.templatetags.static import static
+from django.utils.functional import keep_lazy_text
 from django.utils.text import slugify
 import random
 import string
@@ -127,3 +131,16 @@ def dsfr_input_class_attr(bf: BoundField):
         ):
             bf.field.widget.attrs["class"] = "fr-input"
     return bf
+
+
+def lazy_static(path):
+    """
+    Équivalent du tag Django `{% static %}` à utiliser dans le code.
+
+    Exemple :
+
+    ```python
+    >>> lazy_static("img/logo.png")
+    ```
+    """
+    return keep_lazy_text(functools.partial(static, path))

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -1,0 +1,133 @@
+from typing import Type
+
+from django.forms.widgets import RadioSelect, ChoiceWidget
+
+from dsfr.enums import RichRadioButtonChoices
+
+
+__all__ = ["RichRadioSelect"]
+
+
+class _RichChoiceWidget(ChoiceWidget):
+    inline = False
+
+    def __init__(
+        self, rich_choices: Type[RichRadioButtonChoices], inline=None, attrs=None
+    ):
+        super().__init__(attrs)
+        self.rich_choices = rich_choices
+        if inline is not None:
+            self.inline = inline
+
+    @property
+    def choices(self):
+        return self.rich_choices.choices
+
+    @choices.setter
+    def choices(self, value):
+        """
+        Superseded by self.rich_choices;
+        kept for compatibility with ChoiceWidget.__init__
+        """
+        ...
+
+    def __deepcopy__(self, memo):
+        obj = super().__deepcopy__(memo)
+        obj.rich_choices = self.rich_choices
+        return obj
+
+    def create_option(
+        self, name, value, label, selected, index, subindex=None, attrs=None
+    ):
+        opt = {
+            **super().create_option(
+                name, value, label, selected, index, subindex, attrs
+            ),
+            "inline": self.inline,
+        }
+
+        opt.update(
+            {
+                k: getattr(self.rich_choices(value), k)
+                for k in self.rich_choices.additional_attributes
+            }
+        )
+
+        return opt
+
+
+class RichRadioSelect(_RichChoiceWidget, RadioSelect):
+    """
+    Widget permettant de produire des boutons radio riches. Ce widget fonctionne avec
+    `dsfr.enums.RichRadioButtonChoices`.
+
+    `RichRadioSelect.__init__` prend obligatoirement un argument `rich_choices` de type
+    `RichRadioButtonChoices`.
+
+    Utilisation :
+
+    ```python
+    >>> from enum import auto
+    >>> from django.db.models import IntegerChoices
+    >>> from django import forms
+    >>> from dsfr.forms import DsfrBaseForm
+    >>> from dsfr.utils import lazy_static
+
+    >>> class ExampleRichChoices(RichRadioButtonChoices, IntegerChoices):
+    ...     ITEM_1 = {
+    ...         "value": auto(),
+    ...         "label": "Item 1",
+    ...         "html_label": "<strong>Item 1</strong>",
+    ...         "pictogram": lazy_static("img/placeholder.1x1.png"),
+    ...     }
+    ...     ITEM_2 = {
+    ...         "value": auto(),
+    ...         "label": "Item 2",
+    ...         "html_label": "<strong>Item 2</strong>",
+    ...         "pictogram": lazy_static("img/placeholder.1x1.png"),
+    ...     }
+    ...     ITEM_3 = {
+    ...         "value": auto(),
+    ...         "label": "Item 3",
+    ...         "html_label": "<strong>Item 3</strong>",
+    ...         "pictogram": lazy_static("img/placeholder.1x1.png"),
+    ...     }
+
+    >>> class ExampleForm(DsfrBaseForm):
+    ...     sample_rich_radio = forms.ChoiceField(
+    ...         label="Cases à cocher",
+    ...         required=False,
+    ...         choices=ExampleRichChoices.choices,
+    ...         help_text="Exemple de boutons radios riches",
+    ...         widget=RichRadioSelect(rich_choices=ExampleRichChoices),
+    ...     )
+    ```
+
+    ## `html_label`
+
+    L'attribut `html_label` peut-être utilisé pour déclarer du HTML à insérer dans
+    `<label>`. Le code est automatiquement marqué sûr avec
+    [`django.utils.safestring.mark_safe`][1] et ne produira pas de
+    [problème d'échappement du HTML][2] dans vos templates.
+
+    Si `html_label` n'est pas déclaré par un membre de l'enum, la propriété `html_label`
+    renvoie la valeur de la propriété `label` à la place.
+
+    ## `pictogram`
+
+    L'attribut `pictogram` peut être utilisé pour spécifier le pictogramme du bouton
+    radio riche. Il peut être utilisé en combinaison avec `dsfr.utils.lazy_static`
+    pour charger une ressource statique.
+
+    ## `pictogram_alt`
+
+    L'attribut `pictogram_alt` définit la valeur à mettre dans l'attribut `atl` de la
+    balise `<img>` utilisée dans le bouton radio riche. S'il n'est pas déclaré par
+    l'enum, `RichRadioSelect` ajoute un `alt=""`.
+
+    [1]: https://docs.djangoproject.com/en/5.1/ref/utils/#django.utils.safestring.mark_safe
+    [2]: https://docs.djangoproject.com/en/5.1/ref/templates/language/#automatic-html-escaping
+    """
+
+    template_name = "dsfr/widgets/rich_radio.html"
+    option_template_name = "dsfr/widgets/rich_radio_option.html"

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -1,18 +1,46 @@
+from enum import auto
+
 from django import forms
 from django.forms import (
     ModelForm,
     inlineformset_factory,
 )  # /!\ In order to use formsets
+from django.db.models import IntegerChoices
+
 
 from dsfr.constants import COLOR_CHOICES, COLOR_CHOICES_ILLUSTRATION
+from dsfr.enums import RichRadioButtonChoices
 from dsfr.forms import DsfrBaseForm
 
 # /!\ In order to use formsets
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Field
 
+from dsfr.utils import lazy_static
+from dsfr.widgets import RichRadioSelect
 from example_app.models import Author, Book
 from example_app.utils import populate_genre_choices
+
+
+class ExampleRichChoices(IntegerChoices, RichRadioButtonChoices):
+    ITEM_1 = {
+        "value": auto(),
+        "label": "Item 1",
+        "html_label": "<strong>Item 1</strong>",
+        "pictogram": lazy_static("img/placeholder.1x1.png"),
+    }
+    ITEM_2 = {
+        "value": auto(),
+        "label": "Item 2",
+        "html_label": "<strong>Item 2</strong>",
+        "pictogram": lazy_static("img/placeholder.1x1.png"),
+    }
+    ITEM_3 = {
+        "value": auto(),
+        "label": "Item 3",
+        "html_label": "<strong>Item 3</strong>",
+        "pictogram": lazy_static("img/placeholder.1x1.png"),
+    }
 
 
 class ExampleForm(DsfrBaseForm):
@@ -92,6 +120,22 @@ class ExampleForm(DsfrBaseForm):
         ],
         help_text="Le troisième choix renvoie une erreur s’il est sélectionné",
         widget=forms.CheckboxSelectMultiple,
+    )
+
+    sample_rich_radio = forms.ChoiceField(
+        label="Cases à cocher",
+        required=False,
+        choices=ExampleRichChoices.choices,
+        help_text="Exemple de boutons radios riches",
+        widget=RichRadioSelect(rich_choices=ExampleRichChoices),
+    )
+
+    inline_rich_radio = forms.ChoiceField(
+        label="Cases à cocher",
+        required=False,
+        choices=ExampleRichChoices.choices,
+        help_text="Exemple de boutons radios riches en ligne",
+        widget=RichRadioSelect(rich_choices=ExampleRichChoices, inline=True),
     )
 
     # text blocks

--- a/example_app/utils.py
+++ b/example_app/utils.py
@@ -34,6 +34,7 @@ def format_markdown_from_file(filename: str, ignore_first_line: bool = False) ->
         md = markdown.Markdown(
             extensions=[
                 "markdown.extensions.fenced_code",
+                "markdown.extensions.attr_list",
                 TocExtension(toc_depth="2-6"),
                 CodeHiliteExtension(css_class="dsfr-code"),
             ],


### PR DESCRIPTION
## 🎯 Objectif

Voici ma tentative d'ajouter des boutons radio riches. Je suis un peu sceptique sur cette solution parce qu'elle repose sur une nouvelle forme d'`enum`s, plus complexe et qui repose pas mal sur la métaprogrammation, ce qui peut être difficile à maintenir. Mais pour l'instant, c'est la solution la plus user-friendly que j'ai trouvée. L'idée, c'est de l'utiliser comme ça :

```python
from django import forms
from dsfr.forms import DsfrBaseForm
from dsfr.widgets import RichRadioButtonWidget
from django.utils.safestring import mark_safe


class ComplexChoices(RichRadioButtonChoices):
    ITEM_1 = {
        "value": "Item_1",
        "label": "Item 1",
        "pictogram": "/static/images/item1.png",
        "html_label": mark_safe("<span>Item 1</span>"),
    }
    ITEM_2 = {
        "value": "Item_2",
        "label": "Item 2",
        "pictogram": "/static/images/item2.png",
        "html_label": mark_safe("<span>Item 2</span>"),
    }


class ComplexForm(DsfrBaseForm):
    color_full = forms.ChoiceField(
        label="Choisissez une couleur",
        required=False,
        choices=ComplexChoices.choices,
        widget=RichRadioButtonWidget(rich_choices=ComplexChoices),
    )
```