### PR TITLE
[Bugfix] Correction de l’affichage des erreurs pour les checkbox multiples

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
@@ -22,15 +22,10 @@
         {{ field|dsfr_input_class_attr|attr:"type:checkbox" }}
       {% endif %}
       {% if field.errors %}
-        <div id="{{ field.auto_id }}-desc-error" class="fr-error-text">
+        <div id="{{ field.auto_id }}-desc-error">
           {{ field.errors }}
         </div>
       {% endif %}
     </div>
   </div>
-  {% if field.errors %}
-    <div id="{{ field.auto_id }}-messages">
-      {{ field.errors }}
-    </div>
-  {% endif %}
 </fieldset>

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -82,7 +82,7 @@ class ExampleForm(DsfrBaseForm):
         widget=forms.RadioSelect,
     )
 
-    sample_checkbox = forms.ChoiceField(
+    sample_checkbox = forms.MultipleChoiceField(
         label="Cases à cocher",
         required=False,
         choices=[
@@ -124,7 +124,7 @@ class ExampleForm(DsfrBaseForm):
     def clean_sample_checkbox(self):
         sample_checkbox = self.cleaned_data["sample_checkbox"]
 
-        if sample_checkbox == ["2"]:
+        if "3" in sample_checkbox:
             raise forms.ValidationError("Le troisième choix est interdit")
 
         return sample_checkbox


### PR DESCRIPTION
## 🎯 Objectif
Correction de la checkbox multiple de démo qui ne marche pas, et de l'affichage des erreurs liées

## 🔍 Implémentation
- [x] Correction du type de la checkbox multiple
- [x] Correction du validateur
- [x] Correction de l’affichage des messages d’erreur pour ce type de champ

## 🖼️ Images
![Capture d’écran du 2024-09-17 16-31-55](https://github.com/user-attachments/assets/38ea2abd-267e-4460-b302-4612ab5355d5)
