### PR TITLE
[Formulaires] Autoriser le HTML dans le texte d’aide des champs de formulaire

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
@@ -2,10 +2,12 @@
 {# Generic input snippet used by most of the field types #}
 <div class="{{ field.field.widget.group_class|default:'fr-input-group' }}{% if field.errors %} {{ field.field.widget.group_class|default:'fr-input-group' }}--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %}">
   <label for="{{ field.id_for_label }}" class="fr-label">
+    {# djlint:off #}
     {{ field.label }}{% if field.field.required %}*{% endif %}
     {% if field.help_text %}
-      <span class="fr-hint-text">{{ field.help_text }}</span>
+      <span class="fr-hint-text">{{ field.help_text|safe }}</span>
     {% endif %}
+    {# djlint:on #}
   </label>
   {% if field.errors %}
     {% with aria_describedby="aria-describedby:"|add:field.auto_id|add:"-desc-error" %}

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -49,7 +49,7 @@ class ExampleForm(DsfrBaseForm):
 
     user_email = forms.EmailField(
         label="Adresse électronique",
-        help_text="Format attendu : prenom.nom@domaine.fr",
+        help_text="Format attendu : <code>prenom.nom@domaine.fr</code>",
         required=False,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Sylvain Boissel <sylvain.boissel@beta.gouv.fr>"]
 description = "Integrate the French government Design System into a Django app"
 license = "MIT"
 name = "django-dsfr"
-version = "1.4.1"
+version = "1.4.2"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",


### PR DESCRIPTION
## 🎯 Objectif
Le texte d’aide d’un champ de formulaire doit pouvoir contenir des liens ou de la mise en forme si besoin. Actuellement, il est rendu en texte brut.

## 🔍 Implémentation
- [x] Autorisation du HTML dans le texte d’aide des champs de formulaire

## 🖼️ Images
### Avant
![Capture d’écran du 2024-11-13 17-16-41](https://github.com/user-attachments/assets/96b0cd5f-cda2-4708-8975-edf247c1a1ec)

### Après
![Capture d’écran du 2024-11-13 17-17-01](https://github.com/user-attachments/assets/f119ba5e-3134-4181-a866-a6f69c20c7b7)
