### PR TITLE
[Formulaires] Autoriser le HTML dans le texte d’aide de tous les types de champs de formulaire

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
@@ -10,7 +10,7 @@
   <label for="{{ field.id_for_label }}" class="fr-label">
     {{ field.label_tag }}
     {% if field.help_text %}
-      <span class="fr-hint-text">{{ field.help_text }}</span>
+      <span class="fr-hint-text">{{ field.help_text|safe }}</span>
     {% endif %}
   </label>
   {% if field.errors %}

--- a/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
@@ -9,7 +9,7 @@
       *
     {% endif %}
     {% if field.help_text %}
-      <span class="fr-hint-text">{{ field.help_text }}</span>
+      <span class="fr-hint-text">{{ field.help_text|safe }}</span>
     {% endif %}
   </legend>
   <div class="fr-fieldset__content">

--- a/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
@@ -9,7 +9,7 @@
       *
     {% endif %}
     {% if field.help_text %}
-      <span class="fr-hint-text">{{ field.help_text }}</span>
+      <span class="fr-hint-text">{{ field.help_text|safe }}</span>
     {% endif %}
   </legend>
   <div class="fr-fieldset__content">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = ["Sylvain Boissel <sylvain.boissel@beta.gouv.fr>"]
 description = "Integrate the French government Design System into a Django app"
 license = "MIT"
 name = "django-dsfr"
-version = "1.4.2"
+version = "1.4.3"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",


### PR DESCRIPTION
## 🎯 Objectif
Le texte d’aide d’un champ de formulaire doit pouvoir contenir des liens ou de la mise en forme si besoin. Actuellement, il est rendu en texte brut.

(Même chose que #183 mais pour les autres types de champ)

## 🔍 Implémentation
- [x] Autorisation du HTML dans le texte d’aide des champs de formulaire

## 🖼️ Images
### Avant
![Capture d’écran du 2024-11-13 17-16-41](https://github.com/user-attachments/assets/96b0cd5f-cda2-4708-8975-edf247c1a1ec)

### Après
![Capture d’écran du 2024-11-13 17-17-01](https://github.com/user-attachments/assets/f119ba5e-3134-4181-a866-a6f69c20c7b7)
