### PR TITLE
Correction pyproject.toml pour build/publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ build-backend = "poetry.core.masonry.api"
 packages = [
   {include = "dsfr"},
 ]
+include = ["LICENSE", "README.md", "dsfr/static/dsfr/dist/*/*.*"]
 
 [tool.poetry.group.dev.dependencies]
 coverage = "^5.5"


### PR DESCRIPTION
## 🎯 Objectif
Ajout d’une ligne manquante nécessaire pour la publication du paquet sur Pypi

## 🔍 Implémentation
- [x] correction du `pyproject.toml`
