### PR TITLE
Correction d'un hash d'intégrité vide pour un fichier CSS

### DIFF
--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -11,6 +11,7 @@ from django.utils.html import format_html, format_html_join
 
 from dsfr.checksums import (
     INTEGRITY_CSS,
+    INTEGRITY_UTILITY_CSS,
     INTEGRITY_CSS_ICONS,
     INTEGRITY_FAVICON_APPLE,
     INTEGRITY_FAVICON_ICO,
@@ -58,7 +59,7 @@ def dsfr_css() -> dict:
     """
     tag_data = {}
     tag_data["INTEGRITY_CSS"] = INTEGRITY_CSS
-    tag_data["INTEGRITY_CSS_ICONS"] = INTEGRITY_CSS_ICONS
+    tag_data["INTEGRITY_UTILITY_CSS"] = INTEGRITY_UTILITY_CSS
 
     return {"self": tag_data}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-dsfr"
-version = "2.1.0"
+version = "2.1.1"
 description = "Integrate the French government Design System into a Django app"
 authors = [
     {name = "Sylvain Boissel", email = "sylvain.boissel@beta.gouv.fr"}


### PR DESCRIPTION
## 🎯 Objectif

Dans sa version actuelle, le templatetag `dsfr_css` passe une variable inutile dans le contexte de son template, et oublie par contre une variable qui serait utile.

La conséquence est que dans le rendu HTML, le hash d'intégrité d'un fichier CSS est vide. C'est un problème mineur car les navigateurs ignorent les hashs vides, mais ce sera plus propre avec cette PR.

## 🔍 Implémentation

- Juste remplacer la variable inutile par la variable requise