### PR TITLE
Correction du style des checkbox à sélection multiple

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
@@ -1,5 +1,5 @@
 {% load widget_tweaks dsfr_tags %}
-<fieldset class="fr-fieldset{% if field.errors %} fr-fieldset--error{% endif %} fr-fieldsets"
+<fieldset class="fr-fieldset{% if field.errors %} fr-fieldset--error{% endif %} fr-fieldsets fr-checkbox-group"
           id="checkboxes-{{ field.auto_id }}"
           aria-labelledby="{{ field.auto_id }}-legend{% if field.errors %} {{ field.auto_id }}-messages{% endif %}">
   <legend class="fr-fieldset__legend fr-fieldset__legend--regular"


### PR DESCRIPTION
## 🎯 Objectif

Corrige un bug d'affichage des checkboxes groupées via le widget `CheckboxSelectMultiple`.

## 🔍 Implémentation

Juste ajouter la classe `fr-checkbox-group` au `fieldset` entourant les checkboxes.

## 🖼️ Images

Avant :

![image](https://github.com/user-attachments/assets/d355540f-8bf5-4bf1-9a88-415803de8443)


Après :

![image](https://github.com/user-attachments/assets/35a833bb-468b-4111-bcdf-fefa42ee4232)
