### PR TITLE
Prévient les listes vides

### DIFF
--- a/doc/header.md
+++ b/doc/header.md
@@ -91,3 +91,39 @@ Un bloc `opengraph`, vide par défaut, est fourni pour permettre d’entrer des 
   <meta name="twitter:image:alt" content="[À MODIFIER - République Française - Système de Design de l'État]">
 {% endblock opengraph %}
 ```
+
+## Bloc déprécié
+- Le bloc `header_tools`, qui n’agit que sur l’intérieur de la liste de liens de l’en-tête, pose un problème d’acessibilité si cette liste est vide et va donc être supprimé à terme. Les personnalisations sont à mettre dans le nouveau bloc `header_tools_links`, comme suit :
+
+```{.django}
+<!-- <votre_app>/templates/<votre_app>/base.html -->
+{% extends "dsfr/base.html" %}
+
+<!-- [...] -->
+
+{% block header_tools_links %}
+  <div class="fr-header__tools-links">
+    <ul class="fr-btns-group">
+        <li>
+          <a class="fr-icon-add-circle-line fr-btn" href="[url - à modifier]">Créer un espace</a>
+        </li>
+        <li>
+          <a class="fr-icon-lock-line fr-btn" href="[url - à modifier]">Se connecter</a>
+        </li>
+        <li>
+          <a class="fr-icon-account-line fr-btn" href="[url - à modifier]">S’enregistrer</a>
+        </li>
+    </ul>
+  </div>
+{% endblock header_tools_links %}
+```
+- Inversement, s’il est vide, il faut donc l’indiquer explicitement comme vide. De même, s’il n’y a pas non plus de barre de recherche, indiquer explicitement le bloc `header_tools_wrapper` comme vide :
+
+```{.django}
+<!-- <votre_app>/templates/<votre_app>/base.html -->
+{% extends "dsfr/base.html" %}
+
+<!-- [...] -->
+
+{% block header_tools_wrapper %}{% endblock header_tools_wrapper %}
+```

--- a/doc/header.md
+++ b/doc/header.md
@@ -93,6 +93,14 @@ Un bloc `opengraph`, vide par défaut, est fourni pour permettre d’entrer des 
 ```
 
 ## Bloc déprécié
+### header_tools
+
+<ul class="fr-badge-group">
+  <li><p class="fr-badge fr-badge--new">
+    Nouveau en version 2.2.0</p>
+  </li>
+</ul>
+
 - Le bloc `header_tools`, qui n’agit que sur l’intérieur de la liste de liens de l’en-tête, pose un problème d’acessibilité si cette liste est vide et va donc être supprimé à terme. Les personnalisations sont à mettre dans le nouveau bloc `header_tools_links`, comme suit :
 
 ```{.django}

--- a/dsfr/templates/dsfr/header.html
+++ b/dsfr/templates/dsfr/header.html
@@ -56,25 +56,29 @@
             </p>
           </div>
         </div>
-        <div class="fr-header__tools">
-          <div class="fr-header__tools-links">
-            {% block header_tools %}
-              <ul class="fr-btns-group">
-                <li>
-                  <a class="fr-icon-add-circle-line fr-btn" href="[url - à modifier]">Créer un espace</a>
-                </li>
-                <li>
-                  <a class="fr-icon-lock-line fr-btn" href="[url - à modifier]">Se connecter</a>
-                </li>
-                <li>
-                  <a class="fr-icon-account-line fr-btn" href="[url - à modifier]">S’enregistrer</a>
-                </li>
-              </ul>
-            {% endblock header_tools %}
+        {% block header_tools_wrapper %}
+          <div class="fr-header__tools">
+            {% block header_tools_links %}
+              <div class="fr-header__tools-links">
+                <ul class="fr-btns-group">
+                  {% block header_tools %}
+                    <li>
+                      <a class="fr-icon-add-circle-line fr-btn" href="[url - à modifier]">Créer un espace</a>
+                    </li>
+                    <li>
+                      <a class="fr-icon-lock-line fr-btn" href="[url - à modifier]">Se connecter</a>
+                    </li>
+                    <li>
+                      <a class="fr-icon-account-line fr-btn" href="[url - à modifier]">S’enregistrer</a>
+                    </li>
+                  {% endblock header_tools %}
+                </ul>
+              </div>
+            {% endblock header_tools_links %}
+            {% block header_search %}
+            {% endblock header_search %}
           </div>
-          {% block header_search %}
-          {% endblock header_search %}
-        </div>
+        {% endblock header_tools_wrapper %}
       </div>
     </div>
   </div>

--- a/dsfr/templates/dsfr/header.html
+++ b/dsfr/templates/dsfr/header.html
@@ -58,8 +58,8 @@
         </div>
         <div class="fr-header__tools">
           <div class="fr-header__tools-links">
-            <ul class="fr-btns-group">
-              {% block header_tools %}
+            {% block header_tools %}
+              <ul class="fr-btns-group">
                 <li>
                   <a class="fr-icon-add-circle-line fr-btn" href="[url - à modifier]">Créer un espace</a>
                 </li>
@@ -69,8 +69,8 @@
                 <li>
                   <a class="fr-icon-account-line fr-btn" href="[url - à modifier]">S’enregistrer</a>
                 </li>
-              {% endblock header_tools %}
-            </ul>
+              </ul>
+            {% endblock header_tools %}
           </div>
           {% block header_search %}
           {% endblock header_search %}

--- a/example_app/templates/example_app/blocks/header.html
+++ b/example_app/templates/example_app/blocks/header.html
@@ -24,18 +24,20 @@
 {% endblock service_title %}
 
 {% block header_tools %}
-  <li>
-    <button class="fr-btn--display fr-btn"
-            aria-controls="fr-theme-modal"
-            data-fr-opened="false">
-      {% translate "Display settings" %}
-    </button>
-  </li>
-  {% if "127.0.0.1" in request.get_host %}
+  <ul class="fr-btns-group">
+    <li>
+      <button class="fr-btn--display fr-btn"
+              aria-controls="fr-theme-modal"
+              data-fr-opened="false">
+        {% translate "Display settings" %}
+      </button>
+    </li>
+    {% if "127.0.0.1" in request.get_host %}
     <li>
       {% include "example_app/blocks/language_selector.html" %}
     </li>
-  {% endif %}
+    {% endif %}
+  </ul>
 {% endblock header_tools %}
 
 {# Leave burger_menu and main_menu blocks empty if the main menu is not used #}

--- a/example_app/templates/example_app/blocks/header.html
+++ b/example_app/templates/example_app/blocks/header.html
@@ -24,20 +24,18 @@
 {% endblock service_title %}
 
 {% block header_tools %}
-  <ul class="fr-btns-group">
-    <li>
-      <button class="fr-btn--display fr-btn"
-              aria-controls="fr-theme-modal"
-              data-fr-opened="false">
-        {% translate "Display settings" %}
-      </button>
-    </li>
-    {% if "127.0.0.1" in request.get_host %}
+  <li>
+    <button class="fr-btn--display fr-btn"
+            aria-controls="fr-theme-modal"
+            data-fr-opened="false">
+      {% translate "Display settings" %}
+    </button>
+  </li>
+  {% if "127.0.0.1" in request.get_host %}
     <li>
       {% include "example_app/blocks/language_selector.html" %}
     </li>
-    {% endif %}
-  </ul>
+  {% endif %}
 {% endblock header_tools %}
 
 {# Leave burger_menu and main_menu blocks empty if the main menu is not used #}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-dsfr"
-version = "2.1.0"
+version = "2.2.0"
 description = "Integrate the French government Design System into a Django app"
 authors = [
     {name = "Sylvain Boissel", email = "sylvain.boissel@beta.gouv.fr"}


### PR DESCRIPTION
## 🎯 Objectif

Dans le header il peut y avoir des `<ul>` vide s'il n'y a pas de contenue. 

## 🔍 Implémentation

Mettre la liste à l'intérieur du bloc

## ⚠️ Informations supplémentaires

D'après ce que j'ai pu voir c'est au niveau du select du thème. Sur Wgtail si on choisit de ne pas afficher le select il reste une balise vide.

@Ash-Crow je n'ai pas en tête si ça peut avoir des incidences sur des projets qui utilisent Django DSFR. 

## 🖼️ Images

<img width="857" alt="Transverse 9 3" src="https://github.com/user-attachments/assets/6ff1e425-87ca-4c3f-9ca9-78229197aa0f" />

