### PR TITLE
Lettre d’information et réseaux sociaux : Ajout d’un aside autour du bloc dans la documentation

### DIFF
--- a/doc/follow.md
+++ b/doc/follow.md
@@ -6,9 +6,10 @@ Le bandeau de Lettre d’information et Réseaux Sociaux est géré grâce à un
 
 <!-- [...] -->
 {% block follow_newsletter_social_media %}
-  {% include "dsfr/follow.html" %}
+  <aside role="complementary">
+    {% include "dsfr/follow.html" %}
+  </aside>
 {% endblock follow_newsletter_social_media %}
-
 ```
 
 Il est alors possible de personnaliser la description de la lettre d’information, l’URL d’inscription ainsi que les réseaux sociaux via la configuration du site dans l’administration de Django.

--- a/example_app/management/commands/import_sample_data.py
+++ b/example_app/management/commands/import_sample_data.py
@@ -30,9 +30,9 @@ class Command(BaseCommand):
 
         DsfrSocialMedia.objects.get_or_create(
             site_config=config,
-            title="Mastodon",
-            url="https://social.numerique.gouv.fr/explore",
-            icon_class="fr-btn--mastodon",
+            title="Github",
+            url="https://github.com/numerique-gouv/django-dsfr",
+            icon_class="fr-icon-github-fill",
         )
 
         Genre.objects.get_or_create(code="SF", designation="Science-Fiction")

--- a/example_app/templates/example_app/base.html
+++ b/example_app/templates/example_app/base.html
@@ -17,3 +17,9 @@
 {# djlint:off #}
 {% block lang %}{% get_current_language as LANGUAGE_CODE %}{{ LANGUAGE_CODE }}{% endblock lang %}
 {# djlint:on #}
+
+{% block follow_newsletter_social_media %}
+  <aside role="complementary">
+    {% include "dsfr/follow.html" %}
+  </aside>
+{% endblock follow_newsletter_social_media %}


### PR DESCRIPTION
## 🎯 Objectif
Alternative à #207 : Suite à un audit de numerique.gouv un problème a été remonté, le block newsletter de Sites-Faciles n'est ni dans la balise <main> ni dans la balise <footer>. Une suggestion a été de le mettre dans un `<aside>` : 

> ÀMHA ce bloc répété, complémentaire du contenu principal, est à identifier en tant que tel -> aside (role="complementary")
sinon dans un élément navigation.
le footer (role="contentinfo") est normalement réservé à des métadonnées : de l’information à propos du contenu.
La newsletter n’est pas de l’information à propos du contenu (comme les mentions légales ou la déclaration d’accessibilité), c’est un contenu en soi du site.

## 🔍 Implémentation
- [x] Mise à jour de la documentation pour prendre cela en compte
- [x] Ajout d’un exemple dans l’application d’exemple

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images
![Capture d’écran du 2025-02-26 12-08-27](https://github.com/user-attachments/assets/cc496d4c-c4ba-44de-807f-b5d5925ce4b9)
