### PR TITLE
[FIX] Corriger le rendu de bouton radio inline

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
@@ -3,7 +3,7 @@
   {{ field.as_hidden }}
 {% elif field|widget_type == "checkboxinput" %}
   {% include "dsfr/form_field_snippets/checkbox_snippet.html" %}
-{% elif field|widget_type == "checkboxselectmultiple" %}
+{% elif field|widget_type == "checkboxselectmultiple" or field|widget_type == "inlinecheckboxselectmultiple" %}
   {% include "dsfr/form_field_snippets/checkboxselectmultiple_snippet.html" %}
 {% elif field|widget_type == "radioselect" or field|widget_type == "inlineradioselect" %}
   {% include "dsfr/form_field_snippets/radioselect_snippet.html" %}

--- a/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
@@ -5,7 +5,7 @@
   {% include "dsfr/form_field_snippets/checkbox_snippet.html" %}
 {% elif field|widget_type == "checkboxselectmultiple" %}
   {% include "dsfr/form_field_snippets/checkboxselectmultiple_snippet.html" %}
-{% elif field|widget_type == "radioselect" %}
+{% elif field|widget_type == "radioselect" or field|widget_type == "inlineradioselect" %}
   {% include "dsfr/form_field_snippets/radioselect_snippet.html" %}
 {% elif field|widget_type == "richradioselect" %}
   {% include "dsfr/form_field_snippets/richradioselect_snippet.html" %}

--- a/dsfr/test/test_form_field_snippets.py
+++ b/dsfr/test/test_form_field_snippets.py
@@ -1,0 +1,36 @@
+from django import forms
+from django.template import Context, Template
+from django.test import SimpleTestCase
+
+from dsfr.forms import DsfrBaseForm
+from dsfr.widgets import InlineRadioSelect
+
+
+class RadioSelectTestCase(SimpleTestCase):
+    class DummyForm(DsfrBaseForm):
+        radio_field = forms.ChoiceField(
+            choices=(("a", "bla"), ("i", "bli"), ("o", "blo")),
+            widget=forms.RadioSelect(),
+        )
+
+    class DummyFormWithInlineRadioSelect(DsfrBaseForm):
+        radio_field = forms.ChoiceField(
+            choices=(("a", "bla"), ("i", "bli"), ("o", "blo")),
+            widget=InlineRadioSelect(),
+        )
+
+    def test_not_inline(self):
+        rendered = Template("{{form}}").render(
+            Context({"form": RadioSelectTestCase.DummyForm()})
+        )
+        self.assertFalse(
+            'class="fr-fieldset__element fr-fieldset__element--inline"' in rendered
+        )
+
+    def test_inline(self):
+        rendered = Template("{{form}}").render(
+            Context({"form": RadioSelectTestCase.DummyFormWithInlineRadioSelect()})
+        )
+        self.assertTrue(
+            'class="fr-fieldset__element fr-fieldset__element--inline"' in rendered
+        )

--- a/dsfr/test/test_form_field_snippets.py
+++ b/dsfr/test/test_form_field_snippets.py
@@ -3,7 +3,7 @@ from django.template import Context, Template
 from django.test import SimpleTestCase
 
 from dsfr.forms import DsfrBaseForm
-from dsfr.widgets import InlineRadioSelect
+from dsfr.widgets import InlineRadioSelect, InlineCheckboxSelectMultiple
 
 
 class RadioSelectTestCase(SimpleTestCase):
@@ -30,6 +30,40 @@ class RadioSelectTestCase(SimpleTestCase):
     def test_inline(self):
         rendered = Template("{{form}}").render(
             Context({"form": RadioSelectTestCase.DummyFormWithInlineRadioSelect()})
+        )
+        self.assertTrue(
+            'class="fr-fieldset__element fr-fieldset__element--inline"' in rendered
+        )
+
+
+class CheckboxSelectMultipleTestCase(SimpleTestCase):
+    class DummyForm(DsfrBaseForm):
+        checkbox_field = forms.ChoiceField(
+            choices=(("a", "bla"), ("i", "bli"), ("o", "blo")),
+            widget=forms.CheckboxSelectMultiple(),
+        )
+
+    class DummyFormWithInlineCheckboxSelectMultiple(DsfrBaseForm):
+        checkbox_field = forms.ChoiceField(
+            choices=(("a", "bla"), ("i", "bli"), ("o", "blo")),
+            widget=InlineCheckboxSelectMultiple(),
+        )
+
+    def test_not_inline(self):
+        rendered = Template("{{form}}").render(
+            Context({"form": CheckboxSelectMultipleTestCase.DummyForm()})
+        )
+        self.assertFalse(
+            'class="fr-fieldset__element fr-fieldset__element--inline"' in rendered
+        )
+
+    def test_inline(self):
+        rendered = Template("{{form}}").render(
+            Context(
+                {
+                    "form": CheckboxSelectMultipleTestCase.DummyFormWithInlineCheckboxSelectMultiple()
+                }
+            )
         )
         self.assertTrue(
             'class="fr-fieldset__element fr-fieldset__element--inline"' in rendered

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -5,7 +5,7 @@ from django.forms.widgets import RadioSelect, ChoiceWidget, CheckboxSelectMultip
 from dsfr.enums import RichRadioButtonChoices
 
 
-__all__ = ["RichRadioSelect", "InlineRadioSelect"]
+__all__ = ["RichRadioSelect", "InlineRadioSelect", "InlineCheckboxSelectMultiple"]
 
 
 class _RichChoiceWidget(ChoiceWidget):

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from django.forms.widgets import RadioSelect, ChoiceWidget
+from django.forms.widgets import RadioSelect, ChoiceWidget, CheckboxSelectMultiple
 
 from dsfr.enums import RichRadioButtonChoices
 
@@ -134,4 +134,8 @@ class RichRadioSelect(_RichChoiceWidget, RadioSelect):
 
 
 class InlineRadioSelect(RadioSelect):
+    inline = True
+
+
+class InlineCheckboxSelectMultiple(RadioSelect):
     inline = True

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -137,5 +137,5 @@ class InlineRadioSelect(RadioSelect):
     inline = True
 
 
-class InlineCheckboxSelectMultiple(RadioSelect):
+class InlineCheckboxSelectMultiple(CheckboxSelectMultiple):
     inline = True

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -5,7 +5,7 @@ from django.forms.widgets import RadioSelect, ChoiceWidget
 from dsfr.enums import RichRadioButtonChoices
 
 
-__all__ = ["RichRadioSelect"]
+__all__ = ["RichRadioSelect", "InlineRadioSelect"]
 
 
 class _RichChoiceWidget(ChoiceWidget):
@@ -131,3 +131,7 @@ class RichRadioSelect(_RichChoiceWidget, RadioSelect):
 
     template_name = "dsfr/widgets/rich_radio.html"
     option_template_name = "dsfr/widgets/rich_radio_option.html"
+
+
+class InlineRadioSelect(RadioSelect):
+    inline = True

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -16,7 +16,6 @@ from dsfr.forms import DsfrBaseForm
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Field
 
-from dsfr.templatetags.dsfr_tags import dsfr_inline
 from dsfr.utils import lazy_static
 from dsfr.widgets import (
     RichRadioSelect,

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -18,7 +18,11 @@ from crispy_forms.layout import Layout, Fieldset, Field
 
 from dsfr.templatetags.dsfr_tags import dsfr_inline
 from dsfr.utils import lazy_static
-from dsfr.widgets import RichRadioSelect
+from dsfr.widgets import (
+    RichRadioSelect,
+    InlineRadioSelect,
+    InlineCheckboxSelectMultiple,
+)
 from example_app.models import Author, Book
 from example_app.utils import populate_genre_choices
 
@@ -119,7 +123,7 @@ class ExampleForm(DsfrBaseForm):
         label="Boutons radio inline",
         required=False,
         choices=[(1, "Premier choix"), (2, "Second choix"), (3, "Troisième choix")],
-        widget=forms.RadioSelect,
+        widget=InlineRadioSelect,
     )
 
     sample_checkbox = forms.MultipleChoiceField(
@@ -135,14 +139,14 @@ class ExampleForm(DsfrBaseForm):
     )
 
     sample_checkbox_inline = forms.MultipleChoiceField(
-        label="Cases à cocher",
+        label="Cases à cocher inline",
         required=False,
         choices=[
             ("1", "Premier choix"),
             ("2", "Second choix"),
             ("3", "Troisième choix"),
         ],
-        widget=forms.CheckboxSelectMultiple,
+        widget=InlineCheckboxSelectMultiple,
     )
 
     sample_rich_radio = forms.ChoiceField(
@@ -199,8 +203,6 @@ class ExampleForm(DsfrBaseForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.set_autofocus_on_first_error()
-        dsfr_inline(self["sample_radio_inline"])
-        dsfr_inline(self["sample_checkbox_inline"])
 
 
 class AuthorCreateForm(ModelForm, DsfrBaseForm):


### PR DESCRIPTION
## 🎯 Objectif

Corrige #154 , en rendant possible l'affichage inline des boutons radio au sein d'un formulaire.

## 🔍 Implémentation

C'était juste un petit bug : tout était prévu, sauf que l'attribut `inline`, en tant qu'attribut custom du widget, soit accessible au sein du formulaire via `.attrs.inline` plutôt que `.inline`.

J'ai donc créé un petit test qui mettait le bug en lumière, et qui est maintenant au vert, grâce au simple ajout de `.attrs`.

## ⚠️ Informations supplémentaires

Apparemment j'ai inauguré le fait d'écrire des tests sur les snippets de widget de formulaire, je ne sais pas si je m'y suis pris de la bonne manière, donc peut-être point d'attention particulier là-dessus pendant la relecture.
