### PR TITLE
fix PasswordInput doc

### DIFF
--- a/doc/forms.md
+++ b/doc/forms.md
@@ -46,9 +46,11 @@ Si c’est le cas, il faut soit forcer manuellement les classes à utiliser :
 ```{ .python }
     password = forms.CharField(
         label="Mot de passe", widget=forms.PasswordInput(
-            "autocomplete": "current-password",
-            "required": True,
-            "class": "fr-input my-custom-class"
+            attrs={
+                "autocomplete": "current-password",
+                "required": True,
+                "class": "fr-input my-custom-class"
+            }
         )
     )
 ```


### PR DESCRIPTION
## 🎯 Objectif

_Un résumé de l’objectif de la PR_

Correction minime dans la documentation des formulaires

## 🔍 Implémentation

- Dans le paragraphe "Classes CSS", l'exemple de champ PasswordInput avait une erreur