### PR TITLE
Ajouter les curseurs dans les formulaires

### DIFF
--- a/dsfr/fields.py
+++ b/dsfr/fields.py
@@ -1,0 +1,51 @@
+from django.core.exceptions import ValidationError
+from django.forms.fields import MultiValueField, IntegerField
+
+from .widgets import NumberCursor
+
+__all__ = ["IntegerRangeField"]
+
+
+class IntegerRangeField(MultiValueField):
+    widget = NumberCursor
+
+    """
+    This Field can be used to combine two identical IntegerFields
+    in order to enable the user to select a range with two cursors.
+    The combined value returned is a Python range()
+    """
+
+    def __init__(
+        self, max_value: int = 100, min_value: int = 0, step_size: int = None, **kwargs
+    ):
+        self.max_value, self.min_value, self.step_size = max_value, min_value, step_size
+        super().__init__(
+            fields=(
+                IntegerField(
+                    required=True,
+                    max_value=max_value,
+                    min_value=min_value,
+                    step_size=step_size,
+                ),
+                IntegerField(
+                    required=True,
+                    max_value=max_value,
+                    min_value=min_value,
+                    step_size=step_size,
+                ),
+            ),
+            **kwargs,
+        )
+        self.widget.is_range = True
+
+    def widget_attrs(self, widget):
+        return {"max": self.max_value, "min": self.min_value, "step": self.step_size}
+
+    def compress(self, data_list: list[int]) -> range:
+        if len(data_list) != 2:
+            raise ValidationError("Ce champ nécessite de saisir deux nombres entiers")
+        if self.required and data_list[1] < data_list[0]:
+            raise ValidationError(
+                "Le second nombre doit être supérieur au premier pour déterminer un intervalle"
+            )
+        return range(data_list[0], data_list[1] + 1)

--- a/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
@@ -9,6 +9,8 @@
   {% include "dsfr/form_field_snippets/radioselect_snippet.html" %}
 {% elif field|widget_type == "richradioselect" %}
   {% include "dsfr/form_field_snippets/richradioselect_snippet.html" %}
+{% elif field|widget_type == "numbercursor" %}
+  {% include "dsfr/form_field_snippets/numbercursor_snippet.html" %}
 {% else %}
   {% include "dsfr/form_field_snippets/input_snippet.html" %}
 {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
@@ -1,4 +1,4 @@
-{% load widget_tweaks dsfr_tags %}
+{% load dsfr_tags %}
 {# Generic input snippet used by most of the field types #}
 <div class="{{ field.field.widget.group_class|default:'fr-input-group' }}{% if field.errors %} {{ field.field.widget.group_class|default:'fr-input-group' }}--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %}">
   <label for="{{ field.id_for_label }}" class="fr-label">

--- a/dsfr/templates/dsfr/form_field_snippets/numbercursor_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/numbercursor_snippet.html
@@ -1,0 +1,22 @@
+{% load dsfr_tags %}
+
+<div class="fr-range-group {% if field.errors %}fr-range-group--error{% endif %} {% if field.field.disabled %}fr-range-group--disabled{% endif %}">
+  <label for="{{ field.id_for_label }}" class="fr-label">
+    {# djlint:off #}
+    {{ field.label }}{% if field.field.required %}*{% endif %}
+    {% if field.help_text %}
+      <span class="fr-hint-text" id="{{ field.id_for_label }}_helptext">
+        {{ field.help_text|safe }}, valeur
+        comprise entre {{ field.field.min_value|default_if_none:0 }}
+        et {{ field.field.max_value|default_if_none:100 }}.
+      </span>
+    {% endif %}
+    {# djlint:on #}
+  </label>
+  {{ field|dsfr_input_class_attr }}
+  {% if field.errors %}
+    <div id="{{ field.auto_id }}-desc-error">
+      {{ field.errors }}
+    </div>
+  {% endif %}
+</div>

--- a/dsfr/templates/dsfr/widgets/number_cursor.html
+++ b/dsfr/templates/dsfr/widgets/number_cursor.html
@@ -1,0 +1,33 @@
+<div class="fr-range{% if widget.attrs.step %} fr-range--step{% endif %}{% if is_range %} fr-range--double{% endif %} {{ extra_classes }}"
+     {% if prefix %}data-fr-prefix="{{ prefix }}"{% endif %}
+     {% if suffix %}data-fr-suffix="{{ suffix }}"{% endif %}
+>
+  <span class="fr-range__output">{% if widget.value %}{% if is_range %}{{ widget.value|first }}{% else %}{{ widget.value }}{% endif %}{% endif %}</span>
+  <input id="{{ widget.attrs.id }}{% if is_range %}-low{% endif %}"
+         name="{{ widget.name }}"
+         type="range"
+         {% if widget.attrs.disabled %}disabled{% endif %}
+         {% if widget.attrs.min %}min="{{ widget.attrs.min }}"{% endif %}
+         {% if widget.attrs.max %}max="{{ widget.attrs.max }}"{% endif %}
+         {% if widget.attrs.step %}step="{{ widget.attrs.step }}"{% endif %}
+         {% if widget.value %}value="{% if is_range %}{{ widget.value|first }}{% else %}{{ widget.value }}{% endif %}"{% endif %}
+         {% if required %}required{% endif %}
+         aria-labelledby="{{ widget.attrs.id }}-label"
+         aria-describedby="{{ widget.attrs.id }}-messages"
+  >
+  {% if is_range %}
+    <input id="{{ widget.attrs.id }}{% if is_range %}-high{% endif %}"
+           name="{{ widget.name }}"
+           type="range"
+           min="{{ widget.attrs.min }}"
+           max="{{ widget.attrs.max }}"
+           {% if step %}step="{{ widget.attrs.step }}"{% endif %}
+           {% if widget.value %}value="{{ widget.value|last }}"{% endif %}
+           {% if required %}required{% endif %}
+           aria-labelledby="{{ widget.attrs.id }}-label"
+           aria-describedby="{{ widget.attrs.id }}-messages"
+    >
+  {% endif %}
+  <span class="fr-range__min" aria-hidden="true">{{ widget.attrs.min }}</span>
+  <span class="fr-range__max" aria-hidden="true">{{ widget.attrs.max }}</span>
+</div>

--- a/dsfr/test/test_fields.py
+++ b/dsfr/test/test_fields.py
@@ -1,0 +1,50 @@
+from django.template import Context, Template
+from django.test import SimpleTestCase
+from django.utils.datastructures import MultiValueDict
+
+from dsfr.forms import DsfrBaseForm
+from dsfr.fields import IntegerRangeField
+from dsfr.widgets import NumberCursor
+
+
+class IntegerRangeFieldTestCase(SimpleTestCase):
+    class DummyForm(DsfrBaseForm):
+        integer_range_field = IntegerRangeField()
+
+    class DummyFormWithWidgetCustomizations(DsfrBaseForm):
+        integer_range_field = IntegerRangeField(
+            widget=NumberCursor(extra_classes="fr-range--sm", prefix="~", suffix="%")
+        )
+
+    def test_correct_snippet_and_widget_are_rendered(self):
+        rendered = Template("{{form}}").render(
+            Context({"form": IntegerRangeFieldTestCase.DummyForm()})
+        )
+        self.assertTrue('class="fr-range-group ' in rendered)
+        self.assertTrue('class="fr-range fr-range--double' in rendered)
+        self.assertRegex(
+            rendered.replace("\n", ""),
+            r'<input\s+id="\w+-low"\s+name="integer_range_field"\s+type="range"',
+        )
+        self.assertRegex(
+            rendered.replace("\n", ""),
+            r'<input\s+id="\w+-high"\s+name="integer_range_field"\s+type="range"',
+        )
+
+    def test_widget_customizations_are_applied(self):
+        rendered = Template("{{form}}").render(
+            Context(
+                {"form": IntegerRangeFieldTestCase.DummyFormWithWidgetCustomizations()}
+            )
+        )
+        self.assertRegex(
+            rendered.replace("\n", ""),
+            r'class="fr-range fr-range--double fr-range--sm"\s+data-fr-prefix="~"\s+data-fr-suffix="%"',
+        )
+
+    def test_clean_returns_a_range(self):
+        form = IntegerRangeFieldTestCase.DummyForm(
+            data=MultiValueDict({"integer_range_field": ["10", "50"]})
+        )
+        form.full_clean()
+        self.assertEqual(form.cleaned_data["integer_range_field"], range(10, 51))

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -1,11 +1,23 @@
 from typing import Type
 
-from django.forms.widgets import RadioSelect, ChoiceWidget, CheckboxSelectMultiple
+from django.forms.widgets import (
+    RadioSelect,
+    ChoiceWidget,
+    CheckboxSelectMultiple,
+    NumberInput,
+)
+from django.http import QueryDict
+from django.utils.datastructures import MultiValueDict
 
 from dsfr.enums import RichRadioButtonChoices
 
 
-__all__ = ["RichRadioSelect", "InlineRadioSelect", "InlineCheckboxSelectMultiple"]
+__all__ = [
+    "RichRadioSelect",
+    "InlineRadioSelect",
+    "InlineCheckboxSelectMultiple",
+    "NumberCursor",
+]
 
 
 class _RichChoiceWidget(ChoiceWidget):
@@ -139,3 +151,44 @@ class InlineRadioSelect(RadioSelect):
 
 class InlineCheckboxSelectMultiple(CheckboxSelectMultiple):
     inline = True
+
+
+class NumberCursor(NumberInput):
+    template_name = "dsfr/widgets/number_cursor.html"
+    group_class = "fr-range-group"
+
+    def __init__(
+        self,
+        *args,
+        is_range: bool = False,
+        prefix: str = "",
+        suffix: str = "",
+        extra_classes: str = "",
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.is_range = is_range
+        self.prefix = prefix
+        self.suffix = suffix
+        self.extra_classes = extra_classes
+
+    def get_context(self, *args, **kwargs):
+        context = super().get_context(*args, **kwargs)
+        context.update(
+            {
+                "is_range": self.is_range,
+                "prefix": self.prefix,
+                "suffix": self.suffix,
+                "extra_classes": self.extra_classes,
+            }
+        )
+        return context
+
+    def value_from_datadict(self, data: QueryDict, files: MultiValueDict, name: str):
+        if self.is_range:
+            return data.getlist(name)
+        else:
+            return data.get(name)
+
+    def format_value(self, value):
+        return value

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -10,6 +10,7 @@ from django.db.models import IntegerChoices
 
 from dsfr.constants import COLOR_CHOICES, COLOR_CHOICES_ILLUSTRATION
 from dsfr.enums import RichRadioButtonChoices
+from dsfr.fields import IntegerRangeField
 from dsfr.forms import DsfrBaseForm
 
 # /!\ In order to use formsets
@@ -21,6 +22,7 @@ from dsfr.widgets import (
     RichRadioSelect,
     InlineRadioSelect,
     InlineCheckboxSelectMultiple,
+    NumberCursor,
 )
 from example_app.models import Author, Book
 from example_app.utils import populate_genre_choices
@@ -190,6 +192,43 @@ class ExampleForm(DsfrBaseForm):
 
     # files
     sample_file = forms.FileField(label="Pièce jointe", required=False)
+
+    # range
+    sample_integer_with_cursor = forms.IntegerField(
+        label="Nombre à choisir avec un curseur, simple, requis",
+        help_text="Texte de description additionnel",
+        required=True,
+        widget=NumberCursor(),
+    )
+    sample_integer_with_cursor_disabled = forms.IntegerField(
+        label="Nombre à choisir avec un curseur, désactivé",
+        help_text="Texte de description additionnel",
+        required=False,
+        disabled=True,
+        widget=NumberCursor(),
+    )
+    sample_integer_with_cursor_with_steps = forms.IntegerField(
+        label="Nombre à choisir dans un intervalle explicite, avec un curseur cranté de 5 en 5, petite taille, avec préfixe et suffixe",
+        help_text="Texte de description additionnel",
+        required=False,
+        max_value=70,
+        min_value=10,
+        step_size=5,
+        widget=NumberCursor(extra_classes="fr-range--sm", prefix="~", suffix="%"),
+    )
+    sample_integer_range = IntegerRangeField(
+        label="Intervalle de nombres",
+        help_text="Déplacez les curseurs pour choisir un intervalle",
+        required=False,
+    )
+    sample_integer_range_small = IntegerRangeField(
+        label="Intervalle de nombres, petite taille, suffixe",
+        help_text="Déplacez les curseurs pour choisir un intervalle de prix",
+        required=False,
+        max_value=70,
+        min_value=10,
+        widget=NumberCursor(extra_classes="fr-range--sm", suffix="€"),
+    )
 
     # hidden field
     hidden_input = forms.CharField(widget=forms.HiddenInput(), initial="value")

--- a/example_app/tests.py
+++ b/example_app/tests.py
@@ -5,7 +5,13 @@ from django.urls import reverse
 
 
 class DsfrBaseFormTestCase(TestCase):
-    sample_data = {"user_name": "Example Name", "sample_number": 5, "sample_json": "{}"}
+    sample_data = {
+        "user_name": "Example Name",
+        "sample_number": 5,
+        "sample_json": "{}",
+        "sample_integer_range": ["50", "50"],
+        "sample_integer_range_small": ["50", "50"],
+    }
 
     def test_valid_form(self):
         response = self.client.post(


### PR DESCRIPTION
## 🎯 Objectif

Intégrer le champ de formulaire [Curseur](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/curseur-range/) aux widgets possibles pour les champs de formulaire.

Closes #129 

## 🔍 Implémentation

- Ajout d'un snippet dédié pour pouvoir afficher les bornes inférieures/supérieures automatiquement dans le texte d'aide
- Ajout du widget en lui-même, qui gère les bornes inférieures/supérieures, les crans si besoin, le faire d'être simple ou double, et évidemment un `extra_classes` pour la petite taille
- Ajout d'un nouveau champ Django pour le cas du curseur double qui permet de choisir un intervalle de valeurs ; ce champ retournant un `range` Python

## 🖼️ Images

![image](https://github.com/user-attachments/assets/f01b4dea-298d-435f-b35f-a8768b823365)


## 🏕 Amélioration continue

- Suppression du load `widget_tweaks` là où il n'était pas nécessaire dans `input_snippet.html`
