### PR TITLE
Autoriser la surcharge du heading_tag de dsfr_tile

### DIFF
--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1316,6 +1316,7 @@ def dsfr_tile(*args, **kwargs) -> dict:
         "description",
         "detail",
         "top_detail",
+        "heading_tag",
         "id",
         "enlarge_link",
         "extra_classes",

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -84,6 +84,38 @@ class DsfrThemeModaleTagTest(SimpleTestCase):
         )
 
 
+class DsfrTileTagTest(SimpleTestCase):
+    def test_tile_tag_rendered(self):
+        context = Context()
+        template_to_render = Template("{% load dsfr_tags %} {% dsfr_tile %}")
+        rendered_template = template_to_render.render(context)
+        self.assertInHTML(
+            """
+            <h3 class="fr-tile__title"><a class="fr-tile__link" href=""></a></h3>
+            """.strip(),
+            rendered_template,
+        )
+
+    def test_tile_tag_override_heading_tag_rendered(self):
+        context = Context()
+        template_to_render = Template(
+            "{% load dsfr_tags %} {% dsfr_tile heading_tag='h4' %}"
+        )
+        rendered_template = template_to_render.render(context)
+        self.assertNotInHTML(
+            """
+            <h3 class="fr-tile__title"><a class="fr-tile__link" href=""></a></h3>
+            """.strip(),
+            rendered_template,
+        )
+        self.assertInHTML(
+            """
+            <h4 class="fr-tile__title"><a class="fr-tile__link" href=""></a></h4>
+            """.strip(),
+            rendered_template,
+        )
+
+
 class DsfrAccordionTagTest(SimpleTestCase):
     test_data = {
         "id": "sample-accordion",


### PR DESCRIPTION
## 🎯 Objectif

Cette PR corrige un bug sur `dsfr_tile`, our lequel la surcharge de `heading_tag` a été oubliée dans les paramètres autorisés.

## 🔍 Implémentation

- Un test passant pour couvrir le fonctionnement nominal de `dsfr_tile`
- Un test pour mettre en lumière le bug
- Le correctif du bug qui consiste à juste ajouter la clé `heading_tag` aux clés autorisées
