### PR TITLE
[FIX] Le composant Tooltip, quand cliquable, doit avoir type="button"

### DIFF
--- a/dsfr/templates/dsfr/tooltip.html
+++ b/dsfr/templates/dsfr/tooltip.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% if self.is_clickable|default:False %}
-  <button class="fr-btn--tooltip fr-btn"
+  <button type="button"
+          class="fr-btn--tooltip fr-btn"
           id="button-{{ self.id }}"
           aria-describedby="{{ self.id }}">
     {% translate "Contextual information" %}

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -1117,6 +1117,37 @@ class DsfrTooltipTagTest(SimpleTestCase):
             rendered_template,
         )
 
+    def test_clickable_tooltip_rendered(self):
+        test_data = {
+            "content": "Contenu d’une infobule activée au survol",
+            "label": "Libellé du lien",
+            "id": "tooltip-test",
+            "is_clickable": True,
+        }
+
+        context = Context({"test_data": test_data})
+        template_to_render = Template(
+            "{% load dsfr_tags %} {% dsfr_tooltip test_data %}"
+        )
+        rendered_template = template_to_render.render(context)
+        self.assertInHTML(
+            """
+            <button type="button"
+                    class="fr-btn--tooltip fr-btn"
+                    id="button-tooltip-test"
+                    aria-describedby="tooltip-test"
+            >
+                Information contextuelle
+            </button>
+
+            <span class="fr-tooltip fr-placement"
+                id="tooltip-test"
+                role="tooltip"
+                aria-hidden="true">Contenu d’une infobule activée au survol</span>
+            """,
+            rendered_template,
+        )
+
 
 class DsfrTranscriptionTagTest(SimpleTestCase):
     test_data = {


### PR DESCRIPTION
## 🎯 Objectif

Dans sa version actuelle, le composant Tooltip avec l'option `is_clickable`, est considéré comme un `<button type="submit">`, ce qui le rend considéré par les `<form>` comme un bouton de validation, quand l'utilisateur appuie sur `[Entrée]` dans un champ texte par exemple.

## 🔍 Implémentation

Cette PR ajoute simplement le `type="button"` pour que ce bouton soit considéré comme un simple bouton d'action locale.

De manière similaire à #213 