### PR TITLE
Champ de formulaire pour les contrôles segmentés

### DIFF
--- a/doc/forms.md
+++ b/doc/forms.md
@@ -333,6 +333,7 @@ from dsfr.utils import lazy_static
 from dsfr.enums import RichRadioButtonChoices
 from dsfr.widgets import RichRadioSelect
 
+
 class ExampleRichChoices(RichRadioButtonChoices, IntegerChoices):
     ITEM_1 = {
         "value": auto(),
@@ -353,13 +354,14 @@ class ExampleRichChoices(RichRadioButtonChoices, IntegerChoices):
         "pictogram": lazy_static("img/placeholder.1x1.png"),
     }
 
+
 class ExampleForm(DsfrBaseForm):
     sample_rich_radio = forms.ChoiceField(
         label="Cases à cocher",
         required=False,
         choices=ExampleRichChoices.choices,
         help_text="Exemple de boutons radios riches",
-        widget=RichRadioSelect(rich_choices=ExampleRichChoices),
+        widget=RichRadioSelect(extended_choices=ExampleRichChoices),
     )
 ```
 

--- a/dsfr/enums.py
+++ b/dsfr/enums.py
@@ -422,3 +422,37 @@ class RichRadioButtonChoices(ExtendedChoices):
             if hasattr(self, self.private_variable_name("html_label"))
             else self.label
         )
+
+
+class SegmentedControlChoices(ExtendedChoices):
+    """
+    Version spécialisée de `ExtendedChoices` à utiliser avec
+    `dsfr.widgets.SegmentedControl`. Cette version déclare en plus la propriété
+    `icon` :
+
+    ```python
+    >>> from enum import auto
+    >>> from django.db.models import IntegerChoices
+    >>> class ExampleSegmentedControlChoices(IntegerChoices, SegmentedControlChoices):
+    ...   ITEM_1 = {
+    ...       "value": auto(),
+    ...       "label": "Item 1",
+    ...       "icon": "mail-line",
+    ...   }
+    ...   ITEM_2 = {
+    ...       "value": auto(),
+    ...       "label": "Item 2",
+    ...       "icon": "calendar-line",
+    ...   }
+    ...   ITEM_3 = {
+    ...       "value": auto(),
+    ...       "label": "Item 3",
+    ...       "icon": "archive-line",
+    ...   }
+    ```
+
+    """
+
+    @enum_property
+    def icon(self):
+        return getattr(self, self.private_variable_name("icon"), "")

--- a/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/field_snippet.html
@@ -11,6 +11,8 @@
   {% include "dsfr/form_field_snippets/richradioselect_snippet.html" %}
 {% elif field|widget_type == "numbercursor" %}
   {% include "dsfr/form_field_snippets/numbercursor_snippet.html" %}
+{% elif field|widget_type == "segmentedcontrol" %}
+  {% include "dsfr/form_field_snippets/segmented_control_snippet.html" %}
 {% else %}
   {% include "dsfr/form_field_snippets/input_snippet.html" %}
 {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/segmented_control_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/segmented_control_snippet.html
@@ -1,0 +1,10 @@
+{% load dsfr_tags %}
+
+<div class="fr-input-group">
+  <fieldset class="fr-segmented {{ field.field.widget.extra_classes }}">
+    <legend class="fr-segmented__legend {% if field.field.widget.is_inline %}fr-segmented__legend--inline{% endif %}">
+      {{ field.label }}
+    </legend>
+    {{ field }}
+  </fieldset>
+</div>

--- a/dsfr/templates/dsfr/widgets/segmented_control.html
+++ b/dsfr/templates/dsfr/widgets/segmented_control.html
@@ -1,0 +1,9 @@
+{% load dsfr_tags %}
+
+<div class="fr-segmented__elements">
+{% for group, options, index in widget.optgroups %}
+  {% for option in options %}
+    {% include option.template_name with widget=option %}
+  {% endfor %}
+{% endfor %}
+</div>

--- a/dsfr/templates/dsfr/widgets/segmented_control_option.html
+++ b/dsfr/templates/dsfr/widgets/segmented_control_option.html
@@ -1,0 +1,11 @@
+<div class="fr-segmented__element">
+  <input value="{{ widget.value }}"
+         type="radio"
+         id="segmented-{{ widget.attrs.id }}"
+         name="{{ widget.name }}"
+         {% include "django/forms/widgets/attrs.html" %}
+  >
+  <label class="{% if widget.icon %}fr-icon-{{ widget.icon }}{% endif %} fr-label" for="segmented-{{ widget.attrs.id }}">
+    {{ widget.label }}
+  </label>
+</div>

--- a/dsfr/test/test_form_field_snippets.py
+++ b/dsfr/test/test_form_field_snippets.py
@@ -1,9 +1,15 @@
 from django import forms
+from django.db.models import IntegerChoices
 from django.template import Context, Template
 from django.test import SimpleTestCase
 
+from dsfr.enums import SegmentedControlChoices
 from dsfr.forms import DsfrBaseForm
-from dsfr.widgets import InlineRadioSelect, InlineCheckboxSelectMultiple
+from dsfr.widgets import (
+    InlineRadioSelect,
+    InlineCheckboxSelectMultiple,
+    SegmentedControl,
+)
 
 
 class RadioSelectTestCase(SimpleTestCase):
@@ -68,3 +74,35 @@ class CheckboxSelectMultipleTestCase(SimpleTestCase):
         self.assertTrue(
             'class="fr-fieldset__element fr-fieldset__element--inline"' in rendered
         )
+
+
+class SegmentedControlTestCase(SimpleTestCase):
+    class DummyForm(DsfrBaseForm):
+        class ExampleSegmentedControlChoices(IntegerChoices, SegmentedControlChoices):
+            ITEM_1 = {
+                "value": 1,
+                "label": "Item 1",
+                "icon": "table-line",
+            }
+            ITEM_2 = {
+                "value": 2,
+                "label": "Item 2",
+                "icon": "list-unordered",
+            }
+            ITEM_3 = {
+                "value": 3,
+                "label": "Item 3",
+                "icon": "layout-grid-line",
+            }
+
+        checkbox_field = forms.ChoiceField(
+            choices=ExampleSegmentedControlChoices.choices,
+            widget=SegmentedControl(extended_choices=ExampleSegmentedControlChoices),
+        )
+
+    def test_rendered(self):
+        rendered = Template("{{form}}").render(
+            Context({"form": SegmentedControlTestCase.DummyForm()})
+        )
+        self.assertTrue('class="fr-segmented__elements"' in rendered)
+        self.assertTrue('<label class="fr-icon-table-line fr-label"' in rendered)

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Type
 
 from django.forms.widgets import (
@@ -25,9 +26,21 @@ class _ExtendedChoicesWidget(ChoiceWidget):
     inline = False
 
     def __init__(
-        self, extended_choices: Type[ExtendedChoices], inline=None, attrs=None
+        self,
+        extended_choices: Type[ExtendedChoices],
+        rich_choices: Type[ExtendedChoices] = None,  # /!\ do not use, deprecated
+        inline=None,
+        attrs=None,
     ):
         super().__init__(attrs)
+        if rich_choices:
+            # TODO before v3.0, delete rich_choices argument and this block
+            self.extended_choices = rich_choices
+            warnings.warn(
+                "Argument rich_choices is deprecated, it has been renamed extended_choices and will be removed by the next major release.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
         self.extended_choices = extended_choices
         if inline is not None:
             self.inline = inline

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -17,6 +17,7 @@ __all__ = [
     "InlineRadioSelect",
     "InlineCheckboxSelectMultiple",
     "NumberCursor",
+    "SegmentedControl",
 ]
 
 
@@ -193,3 +194,15 @@ class NumberCursor(NumberInput):
 
     def format_value(self, value):
         return value
+
+
+class SegmentedControl(_ExtendedChoicesWidget, ChoiceWidget):
+    template_name = "dsfr/widgets/segmented_control.html"
+    option_template_name = "dsfr/widgets/segmented_control_option.html"
+
+    def __init__(
+        self, *args, extra_classes: str = "", is_inline: bool = False, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.extra_classes = extra_classes
+        self.is_inline = is_inline

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -9,7 +9,7 @@ from django.forms.widgets import (
 from django.http import QueryDict
 from django.utils.datastructures import MultiValueDict
 
-from dsfr.enums import RichRadioButtonChoices
+from dsfr.enums import ExtendedChoices
 
 
 __all__ = [
@@ -20,32 +20,32 @@ __all__ = [
 ]
 
 
-class _RichChoiceWidget(ChoiceWidget):
+class _ExtendedChoicesWidget(ChoiceWidget):
     inline = False
 
     def __init__(
-        self, rich_choices: Type[RichRadioButtonChoices], inline=None, attrs=None
+        self, extended_choices: Type[ExtendedChoices], inline=None, attrs=None
     ):
         super().__init__(attrs)
-        self.rich_choices = rich_choices
+        self.extended_choices = extended_choices
         if inline is not None:
             self.inline = inline
 
     @property
     def choices(self):
-        return self.rich_choices.choices
+        return self.extended_choices.choices
 
     @choices.setter
     def choices(self, value):
         """
-        Superseded by self.rich_choices;
+        Superseded by self.extended_choices;
         kept for compatibility with ChoiceWidget.__init__
         """
         ...
 
     def __deepcopy__(self, memo):
         obj = super().__deepcopy__(memo)
-        obj.rich_choices = self.rich_choices
+        obj.extended_choices = self.extended_choices
         return obj
 
     def create_option(
@@ -60,15 +60,15 @@ class _RichChoiceWidget(ChoiceWidget):
 
         opt.update(
             {
-                k: getattr(self.rich_choices(value), k)
-                for k in self.rich_choices.additional_attributes
+                k: getattr(self.extended_choices(value), k)
+                for k in self.extended_choices.additional_attributes
             }
         )
 
         return opt
 
 
-class RichRadioSelect(_RichChoiceWidget, RadioSelect):
+class RichRadioSelect(_ExtendedChoicesWidget, RadioSelect):
     """
     Widget permettant de produire des boutons radio riches. Ce widget fonctionne avec
     `dsfr.enums.RichRadioButtonChoices`.
@@ -82,6 +82,7 @@ class RichRadioSelect(_RichChoiceWidget, RadioSelect):
     >>> from enum import auto
     >>> from django.db.models import IntegerChoices
     >>> from django import forms
+    >>> from dsfr.enums import RichRadioButtonChoices
     >>> from dsfr.forms import DsfrBaseForm
     >>> from dsfr.utils import lazy_static
 
@@ -111,7 +112,7 @@ class RichRadioSelect(_RichChoiceWidget, RadioSelect):
     ...         required=False,
     ...         choices=ExampleRichChoices.choices,
     ...         help_text="Exemple de boutons radios riches",
-    ...         widget=RichRadioSelect(rich_choices=ExampleRichChoices),
+    ...         widget=RichRadioSelect(extended_choices=ExampleRichChoices),
     ...     )
     ```
 

--- a/example_app/dsfr_components.py
+++ b/example_app/dsfr_components.py
@@ -1119,34 +1119,7 @@ ALL_IMPLEMENTED_COMPONENTS = dict(
     sorted(unsorted_IMPLEMENTED_COMPONENTS.items(), key=lambda k: k[1]["title"])
 )
 
-NOT_YET_IMPLEMENTED_COMPONENTS = {
-    "radio_rich": {
-        "title": "Bouton radio riche",
-        "doc_url": "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-radio-riche",
-        "example_url": "https://main--ds-gouv.netlify.app/example/component/radio/",
-        "note": """À implémenter au sein des formulaires et non comme une balise.
-        cf. [#126](https://github.com/numerique-gouv/django-dsfr/issues/126)
-        """,
-    },
-    "segmented_control": {
-        "title": "Contrôle segmenté",
-        "doc_url": "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/controle-segmente",
-        "example_url": "https://main--ds-gouv.netlify.app/example/component/segmented/",
-        "storybook_url": "https://storybook.systeme-de-design.gouv.fr/?path=/docs/segmented--docs",
-        "note": """À implémenter au sein des formulaires et non comme une balise.
-        cf. [#128](https://github.com/numerique-gouv/django-dsfr/issues/128)
-        """,
-    },
-    "range": {
-        "title": "Curseur",
-        "doc_url": "https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/curseur-range",
-        "example_url": "https://main--ds-gouv.netlify.app/example/component/range/",
-        "storybook_url": "https://storybook.systeme-de-design.gouv.fr/?path=/docs/range--docs",
-        "note": """À implémenter au sein des formulaires et non comme une balise.
-        cf. [#129](https://github.com/numerique-gouv/django-dsfr/issues/129)
-        """,
-    },
-}
+NOT_YET_IMPLEMENTED_COMPONENTS = {}
 
 # There is no need for specific tags for these
 # (either because the DSFR is implemented globally or because they are

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -174,7 +174,7 @@ class ExampleForm(DsfrBaseForm):
         required=False,
         choices=ExampleRichChoices.choices,
         help_text="Exemple de boutons radios riches",
-        widget=RichRadioSelect(rich_choices=ExampleRichChoices),
+        widget=RichRadioSelect(extended_choices=ExampleRichChoices),
     )
 
     inline_rich_radio = forms.ChoiceField(
@@ -182,7 +182,7 @@ class ExampleForm(DsfrBaseForm):
         required=False,
         choices=ExampleRichChoices.choices,
         help_text="Exemple de boutons radios riches en ligne",
-        widget=RichRadioSelect(rich_choices=ExampleRichChoices, inline=True),
+        widget=RichRadioSelect(extended_choices=ExampleRichChoices, inline=True),
     )
 
     # text blocks

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -9,7 +9,7 @@ from django.db.models import IntegerChoices
 
 
 from dsfr.constants import COLOR_CHOICES, COLOR_CHOICES_ILLUSTRATION
-from dsfr.enums import RichRadioButtonChoices
+from dsfr.enums import RichRadioButtonChoices, SegmentedControlChoices
 from dsfr.fields import IntegerRangeField
 from dsfr.forms import DsfrBaseForm
 
@@ -23,6 +23,7 @@ from dsfr.widgets import (
     InlineRadioSelect,
     InlineCheckboxSelectMultiple,
     NumberCursor,
+    SegmentedControl,
 )
 from example_app.models import Author, Book
 from example_app.utils import populate_genre_choices
@@ -46,6 +47,24 @@ class ExampleRichChoices(IntegerChoices, RichRadioButtonChoices):
         "label": "Item 3",
         "html_label": "<strong>Item 3</strong>",
         "pictogram": lazy_static("img/placeholder.1x1.png"),
+    }
+
+
+class ExampleSegmentedControlChoices(IntegerChoices, SegmentedControlChoices):
+    ITEM_1 = {
+        "value": auto(),
+        "label": "Item 1",
+        "icon": "table-line",
+    }
+    ITEM_2 = {
+        "value": auto(),
+        "label": "Item 2",
+        "icon": "list-unordered",
+    }
+    ITEM_3 = {
+        "value": auto(),
+        "label": "Item 3",
+        "icon": "layout-grid-line",
     }
 
 
@@ -228,6 +247,32 @@ class ExampleForm(DsfrBaseForm):
         max_value=70,
         min_value=10,
         widget=NumberCursor(extra_classes="fr-range--sm", suffix="€"),
+    )
+
+    # segmented control
+    sample_segmented_control = forms.ChoiceField(
+        label="Choix de vue segmenté",
+        choices=ExampleSegmentedControlChoices.choices,
+        required=False,
+        widget=SegmentedControl(extended_choices=ExampleSegmentedControlChoices),
+    )
+    sample_segmented_control_inline = forms.ChoiceField(
+        label="Choix de vue segmenté avec légende inline",
+        choices=ExampleSegmentedControlChoices.choices,
+        required=False,
+        widget=SegmentedControl(
+            extended_choices=ExampleSegmentedControlChoices,
+            is_inline=True,
+        ),
+    )
+    sample_segmented_control_small_no_visible_legend = forms.ChoiceField(
+        label="Choix de vue segmenté petit et sans légende visible",
+        choices=ExampleSegmentedControlChoices.choices,
+        required=False,
+        widget=SegmentedControl(
+            extended_choices=ExampleSegmentedControlChoices,
+            extra_classes="fr-segmented--sm fr-segmented--no-legend",
+        ),
     )
 
     # hidden field


### PR DESCRIPTION
## 🎯 Objectif

Implémente [le contrôle segmenté](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/controle-segmente/) en tant que champ de formulaire Django.

Closes #128 

## 🔍 Implémentation

- Ajout d'un nouveau widget qui gère l'affichage des options ainsi que les différentes variantes (petit, légende inline)
- S'appuie sur les `ExtendedChoices` pour permettre l'ajout d'un icône à chaque option

## 🏕 Amélioration continue

- Juste le renommage d'une classe dont le nom ne reflétait pas son niveau de généricité
- Je me suis aussi permis, dans le dernier commit, de mettre à jour la liste des composants pas encore implémentés, qui est maintenant vide :tada: 

## 🖼️ Images

Les trois variantes : classique, légende inline, pas de légende visible (la dernière est également en petite taille)

![image](https://github.com/user-attachments/assets/e26e50cd-9b75-432c-91aa-00e3221e7c75)

