### PR TITLE
Ajout d‘une vérification si un champ existe dans dsfr_input_class_attr()

### DIFF
--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1590,8 +1590,9 @@ def dsfr_form_field(field) -> dict:
     **Usage**:
         `{% dsfr_form_field field|dsfr_inline %}`
     """
-    if field == '':
-        raise AttributeError("Invalid form field name in dsfr_form_field")
+    if field == "":
+        raise AttributeError("Invalid form field name in dsfr_form_field.")
+
     return {"field": field}
 
 

--- a/dsfr/test/test_fields.py
+++ b/dsfr/test/test_fields.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.template import Context, Template
 from django.test import SimpleTestCase
 from django.utils.datastructures import MultiValueDict
@@ -5,6 +6,37 @@ from django.utils.datastructures import MultiValueDict
 from dsfr.forms import DsfrBaseForm
 from dsfr.fields import IntegerRangeField
 from dsfr.widgets import NumberCursor
+
+
+class FormFieldTestCase(SimpleTestCase):
+    class DummyForm(DsfrBaseForm):
+        user_name = forms.CharField(
+            label="Nom d’utilisateur",
+            max_length=100,
+            widget=forms.TextInput(
+                attrs={
+                    "autocomplete": "username",
+                }
+            ),
+        )
+
+    def test_full_form_works(self):
+        rendered = Template("{{form}}").render(
+            Context({"form": FormFieldTestCase.DummyForm()})
+        )
+        self.assertIn("Nom d’utilisateur", rendered)
+
+    def test_correct_field_works(self):
+        rendered = Template(
+            "{% load dsfr_tags %}{% dsfr_form_field form.user_name %}"
+        ).render(Context({"form": FormFieldTestCase.DummyForm()}))
+        self.assertIn("Nom d’utilisateur", rendered)
+
+    def test_incorrect_field_raises_error(self):
+        with self.assertRaises(AttributeError):
+            _rendered = Template(
+                "{% load dsfr_tags %}{% dsfr_form_field form.unknown_field %}"
+            ).render(Context({"form": FormFieldTestCase.DummyForm()}))
 
 
 class IntegerRangeFieldTestCase(SimpleTestCase):

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -117,7 +117,12 @@ def generate_summary_items(sections_names: list) -> list:
     return items
 
 
-def dsfr_input_class_attr(bf: BoundField):
+def dsfr_input_class_attr(bf: BoundField, *args, **kwargs):
+    if not bf:
+        raise AttributeError(
+            "Either dsfr_form_field or dsfr_input_class_attr has been called with a non-existing field name."
+        )
+
     if bf.is_hidden:
         return bf
     if "class" not in bf.field.widget.attrs:

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -117,11 +117,9 @@ def generate_summary_items(sections_names: list) -> list:
     return items
 
 
-def dsfr_input_class_attr(bf: BoundField):
-    if not bf:
-        raise AttributeError(
-            "Either dsfr_form_field or dsfr_input_class_attr has been called with a non-existing field name."
-        )
+def dsfr_input_class_attr(bf: BoundField | str):
+    if bf == "":
+        raise AttributeError("Invalid form field name passed to dsfr_input_class_attr.")
 
     if bf.is_hidden:
         return bf

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -117,7 +117,7 @@ def generate_summary_items(sections_names: list) -> list:
     return items
 
 
-def dsfr_input_class_attr(bf: BoundField, *args, **kwargs):
+def dsfr_input_class_attr(bf: BoundField):
     if not bf:
         raise AttributeError(
             "Either dsfr_form_field or dsfr_input_class_attr has been called with a non-existing field name."


### PR DESCRIPTION
## 🎯 Objectif
Fix #232

Permet un meilleur message d’erreur quand un champ inexistant est appelé. Malheureusement, le nom du champ est inaccessible à ce stade, s'il n’existe pas c'est une chaîne vide qui est passée au lieu d’un `BoundField` : impossible de donner le nom du champ en erreur dans le message d’erreur


## 🔍 Implémentation
- [x] Ajout d’une vérification à la méthode `dsfr_input_class_attr()`


## 🏕 Amélioration continue
- [x] Ajout de tests basiques sur les formulaires.
