### PR TITLE
Affichage des erreurs de champs

### DIFF
--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1590,6 +1590,8 @@ def dsfr_form_field(field) -> dict:
     **Usage**:
         `{% dsfr_form_field field|dsfr_inline %}`
     """
+    if field == '':
+        raise AttributeError("Invalid form field name")
     return {"field": field}
 
 

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1591,7 +1591,7 @@ def dsfr_form_field(field) -> dict:
         `{% dsfr_form_field field|dsfr_inline %}`
     """
     if field == '':
-        raise AttributeError("Invalid form field name")
+        raise AttributeError("Invalid form field name in dsfr_form_field")
     return {"field": field}
 
 


### PR DESCRIPTION
## 🎯 Objectif

L'issue décrit le problème: https://github.com/numerique-gouv/django-dsfr/issues/232

L'objectif est d'avoir dans la vue debug de la template l'origine exacte de l'erreur quand avec le tag `dsfr_form_field` on ne met pas le bon champs.

## 🔍 Implémentation

Un test au niveau du tag `dsfr_form_field` pour éviter que les typos dans les noms de champs fassent des erreurs très difficiles à remonter

## ⚠️ Informations supplémentaires

On pourrait même tester le type  de variable pour s'assurer que c'est bien un champs de formulaire.
Je n'ai pas encore écrit les tests.


## 🖼️ Images
Maintenant on sait ou regarder si le champs n'est pas bien nommé au niveau de la template
![image](https://github.com/user-attachments/assets/7be9d445-c0d1-4012-a057-f1a6b790c229)
