### PR TITLE
Remplacer h1 par h2 dans les modales

### DIFF
--- a/dsfr/templates/dsfr/theme_modale.html
+++ b/dsfr/templates/dsfr/theme_modale.html
@@ -14,9 +14,9 @@
             </button>
           </div>
           <div class="fr-modal__content">
-            <h1 id="fr-theme-modal-title" class="fr-modal__title">
+            <h2 id="fr-theme-modal-title" class="fr-modal__title">
               {% translate "Display settings" %}
-            </h1>
+            </h2>
             <div id="fr-display" class="fr-form-group fr-display">
               <div class="fr-form-group">
                 <fieldset class="fr-fieldset">

--- a/dsfr/templates/dsfr/transcription.html
+++ b/dsfr/templates/dsfr/transcription.html
@@ -35,10 +35,10 @@
                 </button>
               </div>
               <div class="fr-modal__content">
-                <h1 id="fr-transcription-modal-{{ self.id }}-title"
+                <h2 id="fr-transcription-modal-{{ self.id }}-title"
                     class="fr-modal__title">
                   {{ self.title|default:transcript_label }}
-                </h1>
+                </h2>
                 {{ self.content|safe }}
               </div>
             </div>

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -76,9 +76,9 @@ class DsfrThemeModaleTagTest(SimpleTestCase):
         rendered_template = template_to_render.render(context)
         self.assertInHTML(
             """
-            <h1 id="fr-theme-modal-title" class="fr-modal__title">
+            <h2 id="fr-theme-modal-title" class="fr-modal__title">
                 Paramètres d’affichage
-            </h1>
+            </h2>
             """,
             rendered_template,
         )
@@ -1199,10 +1199,10 @@ class DsfrTranscriptionTagTest(SimpleTestCase):
                                             </button>
                                         </div>
                                         <div class="fr-modal__content">
-                                            <h1 id="fr-transcription-modal-transcription-test-title"
+                                            <h2 id="fr-transcription-modal-transcription-test-title"
                                                 class="fr-modal__title">
                                                 Transcription
-                                            </h1>
+                                            </h2>
                                             <div><p>Courte transcription basique</p></div>
                                         </div>
                                     </div>

--- a/example_app/templates/example_app/example_consent_modale.html
+++ b/example_app/templates/example_app/example_consent_modale.html
@@ -13,9 +13,9 @@
             </button>
           </div>
           <div class="fr-modal__content">
-            <h1 id="fr-consent-modal-title" class="fr-modal__title">
+            <h2 id="fr-consent-modal-title" class="fr-modal__title">
               Panneau de gestion des cookies
-            </h1>
+            </h2>
             <div class="fr-consent-manager">
               <!-- Finalités -->
               <div class="fr-consent-service fr-consent-manager__header">

--- a/example_app/test/test_views.py
+++ b/example_app/test/test_views.py
@@ -29,7 +29,7 @@ class BasicPagesTest(TestCase):
             response.content.decode(),
         )
         self.assertInHTML(
-            """<h1 id="fr-theme-modal-title" class="fr-modal__title">Paramètres d’affichage</h1>""",
+            """<h2 id="fr-theme-modal-title" class="fr-modal__title">Paramètres d’affichage</h2>""",
             response.content.decode(),
         )
 
@@ -42,7 +42,7 @@ class BasicPagesTest(TestCase):
             response.content.decode(),
         )
         self.assertInHTML(
-            """<h1 id="fr-theme-modal-title" class="fr-modal__title">Display settings</h1>""",
+            """<h2 id="fr-theme-modal-title" class="fr-modal__title">Display settings</h2>""",
             response.content.decode(),
         )
 


### PR DESCRIPTION
## 🎯 Objectif
Les modales ont actuellement une arborescence des titres séparées de la principale, conformément à ce qui est recommandé dans https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/modale/

Cependant, cela pose problème avec des outils d'analyse mal conçus qui ne séparent pas les arborescences. Par exemple https://www.webrankinfo.com/outils/balises-h1-h6.php affiche

```
..<h1> Créez un site en autonomie

....<h2> Vous êtes agent de l’État ? Publiez un site internet ou intranet conforme au DSFR, sans coder ni peser sur votre budget.

....<h2> Trois bonnes raisons d'utiliser Sites Faciles

......<h3> Créez un site conforme

......<h3> Travaillez en autonomie

[...]

....<h2> La feuille de route de Sites Faciles Étape 3 sur 4

....<h2> Améliorons Sites Faciles ensemble

....<h2> Abonnez-vous à notre lettre d’information

..<h1> Paramètres d’affichage
```

## 🔍 Implémentation
- [x] Remplacement des h1 par des h2

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue

- _(optionnel) Une liste d’autres modifications pas en lien direct avec la PR_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
