### PR TITLE
Ajout de modèles d'issue Github

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -1,0 +1,34 @@
+---
+name: 🐛 Rapporter un bug
+about: Rapporter un bug pour améliorer Django-DSFR
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## 🐛 Décrire le bug
+Une description claire et précise du bug.
+
+## 🪜 Les étapes pour reproduire le bug
+Exemple :
+1. Aller à  '...'
+2. Cliquer sur  '....'
+3. Scroller jusqu’à '....'
+4. Réduire la page
+5. Le problème apparaît
+
+## 🦋 Comportement attendu
+Une description claire et concise de ce qui devrait se produire.
+
+## 🖼️ Capture d’écran
+Ajouter des captures d’écran ou un exemple de code pour préciser le bug et le contexte.
+
+## 🖥️ Configuration et système utilisé
+- **Version de Django-DSFR : **
+- **Appareil (mobile, tablette, desktop) : **
+- **Système d’exploitation : **
+- **Navigateur et version : **
+
+## ℹ️ Informations complémentaires
+Ajouter toute autre information concernant le problème.

--- a/.github/ISSUE_TEMPLATE/2-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/2-suggestion.md
@@ -1,0 +1,22 @@
+---
+name: 🧬 Proposer une évolution
+about: Suggérer une nouvelle idée, une amélioration, à Django-DSFR
+title: ''
+labels: évolution
+assignees: ''
+
+---
+
+## 🧬 Décrire votre suggestion
+Si votre suggestion concerne un composant existant, merci de décrire le problème rencontré de façon claire et concise
+Exemple : sur le composant [...], je ne peux pas [...].
+
+## 🧠 Comportement souhaité
+Une description claire et concise de ce que vous souhaitez qu’il se passe.
+
+## 🔮 Autres possibilités
+Une description précise de toutes les solutions ou fonctionnalités que vous avez considérées/essayées.
+
+## ℹ️ Contexte & informations complémentaires
+Préciser le contexte, les cas d’usages ou scénarios envisageables.
+Ajouter des captures d’écrans pour clarifier la demande.

--- a/.github/ISSUE_TEMPLATE/3-doc.md
+++ b/.github/ISSUE_TEMPLATE/3-doc.md
@@ -1,0 +1,17 @@
+---
+name: 📔 Amélioration de la documentation
+about: Rapporter une erreur ou proposer une suggestion pour améliorer la documentation du DSFR.
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+##  📔 Documentation associée
+Si la suggestion concerne une documentation existante, préciser de laquelle il s’agit. Ajouter un lien si possible.
+
+##  🔮 Suggestion
+Comment cette documentation pourrait être améliorée.
+
+## 🛈 Sources (si applicable)
+Merci de fournir les différentes sources et recherches qui pourraient appuyer cette suggestion.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Contactez-nous
+    url: https://mattermost.incubateur.net/betagouv/channels/domaine-django
+    about: Contactez-nous sur le canal Mattermost


### PR DESCRIPTION
## 🎯 Objectif
Ajout de [modèles d'issues pour Github](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser), similaires au modèle de PR déjà existant et inspirés de [ceux du DSFR](https://github.com/GouvernementFR/dsfr/tree/main/.github/ISSUE_TEMPLATE).

## 🔍 Implémentation
- [x] Ajout des modèles
