### PR TITLE
Integrity checks optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ update_dsfr:
 
 .PHONY: upgrade
 upgrade:
-    uv lock --upgrade
+	uv lock --upgrade
 	uv run pre-commit autoupdate
 	@make deprecation-warning
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -62,6 +62,10 @@ TEMPLATES = [
 ]
 ```
 
+## Paramètres (optionnels)
+- `DSFR_CHECK_DEPRECATED` (défaut: `False`) : si `True`, vérifie la présence de paramètres obsolètes à l’intérieur des template tags
+- `DSFR_USE_INTEGRITY_CHECKSUMS`  (défaut: `True`)  : si `True`, intègre des checksums d’intégrité sur les fichiers CSS et JS globaux. À désactiver si cela pose des problèmes avec d’autres modules Django comme Whitenoise.
+
 - Créez un objet "DsfrConfig" dans le panneau d’administration (section Système de design de l’État > Configurations.)
 
 ## Application d’exemple

--- a/dsfr/templates/dsfr/global_css.html
+++ b/dsfr/templates/dsfr/global_css.html
@@ -1,10 +1,10 @@
 {% load static %}
 <link rel="stylesheet"
       href="{% static 'dsfr/dist/dsfr/dsfr.min.css' %}"
-      integrity="{{ self.INTEGRITY_CSS }}">
+      {% if self.USE_INTEGRITY_CHECKSUMS %}integrity="{{ self.INTEGRITY_CSS }}"{% endif %}>
 <link rel="stylesheet"
       href="{% static 'dsfr/dist/utility/utility.min.css' %}"
-      integrity="{{ self.INTEGRITY_UTILITY_CSS }}">
+      {% if self.USE_INTEGRITY_CHECKSUMS %}integrity="{{ self.INTEGRITY_UTILITY_CSS }}"{% endif %}>
 <link rel="stylesheet" href="{% static 'css/dsfr-django-overrides.css' %}">
 
 <meta name="theme-color" content="#000091">

--- a/dsfr/templates/dsfr/global_js.html
+++ b/dsfr/templates/dsfr/global_js.html
@@ -1,9 +1,9 @@
 {% load static %}
 <script type="module"
         src="{% static 'dsfr/dist/dsfr/dsfr.module.min.js' %}"
-        integrity="{{ self.INTEGRITY_JS_MODULE }}"
+        {% if self.USE_INTEGRITY_CHECKSUMS %}integrity="{{ self.INTEGRITY_JS_MODULE }}"{% endif %}
         {% if self.nonce %} nonce="{{self.nonce}}"{% endif %}></script>
 <script nomodule
         src="{% static 'dsfr/dist/dsfr/dsfr.nomodule.min.js' %}"
-        integrity="{{ self.INTEGRITY_JS_NOMODULE }}"
+        {% if self.USE_INTEGRITY_CHECKSUMS %}integrity="{{ self.INTEGRITY_JS_NOMODULE }}"{% endif %}
         {% if self.nonce %} nonce="{{self.nonce}}"{% endif %}></script>

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -56,6 +56,13 @@ def dsfr_css() -> dict:
     tag_data["INTEGRITY_CSS"] = INTEGRITY_CSS
     tag_data["INTEGRITY_UTILITY_CSS"] = INTEGRITY_UTILITY_CSS
 
+    tag_data["USE_INTEGRITY_CHECKSUMS"] = True
+    if (
+        hasattr(settings, "DSFR_USE_INTEGRITY_CHECKSUMS")
+        and settings.DSFR_USE_INTEGRITY_CHECKSUMS is False
+    ):
+        tag_data["USE_INTEGRITY_CHECKSUMS"] = False
+
     return {"self": tag_data}
 
 
@@ -78,6 +85,13 @@ def dsfr_js(context, *args, **kwargs) -> dict:
 
     tag_data["INTEGRITY_JS_MODULE"] = INTEGRITY_JS_MODULE
     tag_data["INTEGRITY_JS_NOMODULE"] = INTEGRITY_JS_NOMODULE
+
+    tag_data["USE_INTEGRITY_CHECKSUMS"] = True
+    if (
+        hasattr(settings, "DSFR_USE_INTEGRITY_CHECKSUMS")
+        and settings.DSFR_USE_INTEGRITY_CHECKSUMS is False
+    ):
+        tag_data["USE_INTEGRITY_CHECKSUMS"] = False
 
     return {"self": tag_data}
 

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -1,4 +1,4 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from django.template import Context, Template
 from unittest.mock import MagicMock
 
@@ -16,7 +16,17 @@ class DsfrCssTagTest(SimpleTestCase):
         template_to_render = Template("{% load dsfr_tags %} {% dsfr_css %}")
         rendered_template = template_to_render.render(context)
         self.assertInHTML(
-            f'<link rel="stylesheet" href="/django-dsfr/static/dsfr/dist/dsfr/dsfr.min.css"  integrity="{ INTEGRITY_CSS }">',  # noqa
+            f'<link rel="stylesheet" href="/django-dsfr/static/dsfr/dist/dsfr/dsfr.min.css"  integrity="{ INTEGRITY_CSS }">',
+            rendered_template,
+        )
+
+    @override_settings(DSFR_USE_INTEGRITY_CHECKSUMS=False)
+    def test_css_tag_integrity_checksum_can_be_disabled(self):
+        context = Context()
+        template_to_render = Template("{% load dsfr_tags %} {% dsfr_css %}")
+        rendered_template = template_to_render.render(context)
+        self.assertInHTML(
+            '<link rel="stylesheet" href="/django-dsfr/static/dsfr/dist/dsfr/dsfr.min.css">',
             rendered_template,
         )
 
@@ -30,7 +40,20 @@ class DsfrJsTagTest(SimpleTestCase):
             f"""
             <script type="module" src="/django-dsfr/static/dsfr/dist/dsfr/dsfr.module.min.js" integrity="{ INTEGRITY_JS_MODULE }"></script>
             <script nomodule src="/django-dsfr/static/dsfr/dist/dsfr/dsfr.nomodule.min.js" integrity="{ INTEGRITY_JS_NOMODULE }"></script>
-            """,  # noqa
+            """,
+            rendered_template,
+        )
+
+    @override_settings(DSFR_USE_INTEGRITY_CHECKSUMS=False)
+    def test_js_tag_integrity_checksum_can_be_disabled(self):
+        context = Context()
+        template_to_render = Template("{% load dsfr_tags %} {% dsfr_js %}")
+        rendered_template = template_to_render.render(context)
+        self.assertInHTML(
+            """
+            <script type="module" src="/django-dsfr/static/dsfr/dist/dsfr/dsfr.module.min.js"></script>
+            <script nomodule src="/django-dsfr/static/dsfr/dist/dsfr/dsfr.nomodule.min.js"></script>
+            """,
             rendered_template,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-dsfr"
-version = "3.0.0"
+version = "3.1.0"
 description = "Integrate the French government Design System into a Django app"
 authors = [{ name = "Sylvain Boissel", email = "sylvain.boissel@beta.gouv.fr" }]
 requires-python = "<4.0,>=3.10"


### PR DESCRIPTION
## 🎯 Objectif
Rend les checksums d'intégrité optionnels. Tentative pour résoudre #226 

## 🔍 Implémentation
- [x] Ajout d’un setting dédié `DSFR_USE_INTEGRITY_CHECKSUMS` (défaut : True)
- [x] Mise à jour des tests unitaires
- [x] Mise à jour de la documentation

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d’environnement, etc._

## 🏕 Amélioration continue
- [x] Correction d’un bug sur le `Makefile`

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d’écran, si pertinent_
