### PR TITLE
Security patch: don't trust data by default in tables

### DIFF
--- a/dsfr/templates/dsfr/table.html
+++ b/dsfr/templates/dsfr/table.html
@@ -9,7 +9,7 @@
               <tr>
                 {% for cell in self.header %}
                   <th scope="col">
-                    {{ cell|safe }}
+                    {{ cell }}
                   </th>
                 {% endfor %}
               </tr>
@@ -20,7 +20,7 @@
               <tr>
                 {% for cell in row %}
                   <td>
-                    {{ cell|safe }}
+                    {{ cell }}
                   </td>
                 {% endfor %}
               </tr>

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1154,7 +1154,7 @@ def dsfr_table(*args, **kwargs) -> dict:
     ```python
     data_dict = {
         "caption": "The title of the table",
-        "content": "A list of rows, each row being a list of cells itself",
+        "content": "A list of rows, each row being a list of cells itself; escaped by default",
         "extra_classes": "(Optional) string with names of extra classes",
         "header": "(Optional) list of cells for the table header."
     }
@@ -1162,6 +1162,16 @@ def dsfr_table(*args, **kwargs) -> dict:
 
     All of the keys of the dict can be passed directly as named parameters of the tag.
 
+    **Warning**:When rendering the table, the content is untrusted and escaped by DTL by default as
+    it could come from a user input. `content` is trusted HTML, you should provide it like this:
+
+     ```python
+     from django.utils.safestring import mark_safe
+
+    data_dict = {
+        "content": mark_safe("<b>User input</b>")
+    }
+    ```
 
     Relevant `extra_classes`:
 


### PR DESCRIPTION
## 🎯 Objectif

Comme discuté sur Mattermost, cette PR supprime la confiance par défault dans les cellules du tableau généré par `dsfr_table` et documente comment protéger le HTML contre l'échappement.

C'est évidemment un breaking change, donc je peux proposer une configuration `DSFR_SAFE_STRING_DEFAULT` qui est à `True` par défaut avec un warning qui indique que l'option disparaîtra à la prochaine majeure et qu'il faudra utiliser `mark_safe`.

Je réflchis à retirer le filtre `safe` à d'autres endroits aussi.