### PR TITLE
update service-public.fr footer link to service-public.gouv.fr

### DIFF
--- a/dsfr/templates/dsfr/footer.html
+++ b/dsfr/templates/dsfr/footer.html
@@ -57,10 +57,10 @@
           <li class="fr-footer__content-item">
             <a target="_blank"
                rel="noopener external"
-               title="service-public.fr - {{ new_window_label }}"
+               title="service-public.gouv.fr - {{ new_window_label }}"
                id="footer__content-link-servicepublic"
                class="fr-footer__content-link"
-               href="https://service-public.fr">service-public.fr</a>
+               href="https://service-public.gouv.fr">service-public.gouv.fr</a>
           </li>
           <li class="fr-footer__content-item">
             <a target="_blank"


### PR DESCRIPTION
## 🎯 Objectif

service-public.fr est devenu service-public.gouv.fr
Modification du lien dans le footer pour correspondre au DSFR : https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pied-de-page

## 🔍 Implémentation

- Lien footer service-public.fr -> service-public.gouv.fr
