### PR TITLE
Ajouter le support des data-attributes au composant button

### DIFF
--- a/dsfr/templates/dsfr/button.html
+++ b/dsfr/templates/dsfr/button.html
@@ -4,6 +4,6 @@
         {% if self.is_disabled %}disabled{% endif %}
         type="{{ self.type | default:'submit' }}"
         {% if self.name %}name="{{ self.name }}"{% endif %}
-        {{ self|data_attributes|safe }}>
+        {{ self|data_attributes }}>
   {{ self.label }}
 </button>

--- a/dsfr/templates/dsfr/button.html
+++ b/dsfr/templates/dsfr/button.html
@@ -1,7 +1,9 @@
+{% load dsfr_tags %}
 <button class="fr-btn{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}"
         onclick="{{ self.onclick }}"
         {% if self.is_disabled %}disabled{% endif %}
         type="{{ self.type | default:'submit' }}"
-        {% if self.name %}name="{{ self.name }}"{% endif %}>
+        {% if self.name %}name="{{ self.name }}"{% endif %}
+        {{ self|data_attributes|safe }}>
   {{ self.label }}
 </button>

--- a/dsfr/templates/dsfr/link.html
+++ b/dsfr/templates/dsfr/link.html
@@ -1,7 +1,8 @@
-{% load i18n %}
+{% load dsfr_tags i18n %}
 <a class="fr-link{% if self.is_external %} fr-icon-external-link-line fr-link--icon-right{% endif %}{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}"
    {% if self.url is None %}aria-disabled="true" role="link"{% else %}href="{{ self.url }}"{% endif %}
-   {% if self.is_external %}target="_blank" rel="noopener noreferrer"{% endif %}>
+   {% if self.is_external %}target="_blank" rel="noopener noreferrer"{% endif %}
+   {{ self|data_attributes|safe }}>
   {{ self.label }}
   {% if self.is_external %}
     <span class="fr-sr-only">{% translate "Opens a new window" %}</span>

--- a/dsfr/templates/dsfr/link.html
+++ b/dsfr/templates/dsfr/link.html
@@ -2,7 +2,7 @@
 <a class="fr-link{% if self.is_external %} fr-icon-external-link-line fr-link--icon-right{% endif %}{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}"
    {% if self.url is None %}aria-disabled="true" role="link"{% else %}href="{{ self.url }}"{% endif %}
    {% if self.is_external %}target="_blank" rel="noopener noreferrer"{% endif %}
-   {{ self|data_attributes|safe }}>
+   {{ self|data_attributes }}>
   {{ self.label }}
   {% if self.is_external %}
     <span class="fr-sr-only">{% translate "Opens a new window" %}</span>

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -9,6 +9,7 @@ from django.template import Template
 from django.template.context import Context
 from django.utils.html import format_html, format_html_join
 
+
 from dsfr.checksums import (
     INTEGRITY_CSS,
     INTEGRITY_UTILITY_CSS,
@@ -1735,6 +1736,20 @@ def dsfr_inline(field):
     """
     field.field.widget.inline = True
     return field
+
+
+@register.filter
+def data_attributes(tag_data):
+    print("COUCOU", tag_data)
+    # TODO: raise value error if dict contains data-
+    if tag_data.get("data_attributes"):
+        return " ".join(
+            [
+                f"data-{key}={value}"
+                for key, value in tag_data["data_attributes"].items()
+            ]
+        )
+    return ""
 
 
 # Deprecated tags

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1743,7 +1743,7 @@ def data_attributes(tag_data):
     if tag_data.get("data_attributes"):
         return " ".join(
             [
-                f"data-{key}={value}"
+                f'data-{key}="{value}"'
                 for key, value in tag_data["data_attributes"].items()
             ]
         )

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1740,14 +1740,10 @@ def dsfr_inline(field):
 
 @register.filter
 def data_attributes(tag_data):
-    if tag_data.get("data_attributes"):
-        return " ".join(
-            [
-                f'data-{key}="{value}"'
-                for key, value in tag_data["data_attributes"].items()
-            ]
-        )
-    return ""
+    attrs = tag_data.get("data_attributes")
+    if not attrs:
+        return ""
+    return format_html_join(" ", 'data-{}="{}"', attrs.items())
 
 
 # Deprecated tags

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1740,8 +1740,6 @@ def dsfr_inline(field):
 
 @register.filter
 def data_attributes(tag_data):
-    print("COUCOU", tag_data)
-    # TODO: raise value error if dict contains data-
     if tag_data.get("data_attributes"):
         return " ".join(
             [

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -7,7 +7,7 @@ from dsfr.checksums import (
     INTEGRITY_JS_MODULE,
     INTEGRITY_JS_NOMODULE,
 )
-from dsfr.templatetags.dsfr_tags import concatenate, hyphenate
+from dsfr.templatetags.dsfr_tags import concatenate, hyphenate, data_attributes
 
 
 class DsfrCssTagTest(SimpleTestCase):
@@ -1400,3 +1400,21 @@ class StrfmtTestCase(SimpleTestCase):
                 )
             ),
         )
+
+
+class DataAttributesFilterTest(SimpleTestCase):
+    def test_returns_empty_string_if_no_data_attributes(self):
+        self.assertEqual(data_attributes({}), "")
+
+    def test_returns_single_data_attribute(self):
+        self.assertEqual(
+            data_attributes({"data_attributes": {"role": "admin"}}), 'data-role="admin"'
+        )
+
+    def test_returns_multiple_data_attributes(self):
+        result = data_attributes({"data_attributes": {"role": "admin", "id": "123"}})
+        # Since dict order is preserved in Python 3.7+, output order will follow insertion order
+        self.assertEqual(result, 'data-role="admin" data-id="123"')
+
+    def test_returns_empty_string_if_data_attributes_empty_dict(self):
+        self.assertEqual(data_attributes({"data_attributes": {}}), "")

--- a/dsfr/test/test_utils.py
+++ b/dsfr/test/test_utils.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from dsfr.utils import generate_random_id, generate_summary_items
+from dsfr.utils import generate_random_id, generate_summary_items, parse_tag_args
 
 
 class GenerateRandomIdTestCase(SimpleTestCase):
@@ -28,4 +28,49 @@ class GenerateSummaryItemsTestCase(SimpleTestCase):
                 {"label": "Second élément", "link": "#second-element"},
                 {"label": "Dernier", "link": "#dernier"},
             ],
+        )
+
+
+class TestParseTagArgs(SimpleTestCase):
+    def test_parse_tag_args_with_args_only(self):
+        self.assertEqual(
+            parse_tag_args([{"coucou": "youpi"}], {}, ["coucou"]), {"coucou": "youpi"}
+        )
+
+    def test_parse_tag_args_with_kwargs_only(self):
+        self.assertEqual(
+            parse_tag_args(None, {"coucou": "youpi"}, ["coucou"]), {"coucou": "youpi"}
+        )
+
+    def test_parse_tag_args_with_data_attributes(self):
+        self.assertEqual(
+            parse_tag_args(
+                [{}],
+                {"data_test": "value", "data_another": "thing"},
+                [],
+            ),
+            {"data_attributes": {"test": "value", "another": "thing"}},
+        )
+
+    def test_parse_tag_args_with_allowed_and_data_attributes(self):
+        self.assertEqual(
+            parse_tag_args(
+                [{"foo": "bar"}],
+                {"coucou": "yes", "data_role": "admin"},
+                ["coucou", "foo"],
+            ),
+            {"foo": "bar", "coucou": "yes", "data_attributes": {"role": "admin"}},
+        )
+
+    def test_parse_tag_args_with_disallowed_keys(self):
+        # "not_allowed" should be ignored completely
+        self.assertEqual(
+            parse_tag_args(None, {"not_allowed": "oops"}, ["coucou"]),
+            {},
+        )
+
+    def test_parse_tag_args_with_empty_inputs(self):
+        self.assertEqual(
+            parse_tag_args(None, {}, []),
+            {},
         )

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -66,7 +66,7 @@ def parse_tag_args(args, kwargs, allowed_keys: list) -> dict:
             tag_data[k] = kwargs[k]
         elif k.startswith("data_"):
             _, _, attribute = k.partition("data_")
-            data_attributes[attribute] = kwargs[k]
+            data_attributes[attribute.replace("_", "-")] = kwargs[k]
 
     if data_attributes:
         tag_data = {**tag_data, "data_attributes": data_attributes}

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -61,7 +61,7 @@ def parse_tag_args(args, kwargs, allowed_keys: list) -> dict:
         tag_data = args[0].copy()
 
     for k in kwargs:
-        if k in allowed_keys:
+        if k in [*allowed_keys, "attrs"]:
             tag_data[k] = kwargs[k]
 
     return tag_data

--- a/dsfr/utils.py
+++ b/dsfr/utils.py
@@ -56,14 +56,20 @@ def parse_tag_args(args, kwargs, allowed_keys: list) -> dict:
     Allows to use a tag with either all the arguments in a dict or by declaring them separately
     """
     tag_data = {}
+    data_attributes = {}
 
     if args:
         tag_data = args[0].copy()
 
     for k in kwargs:
-        if k in [*allowed_keys, "attrs"]:
+        if k in allowed_keys:
             tag_data[k] = kwargs[k]
+        elif k.startswith("data_"):
+            _, _, attribute = k.partition("data_")
+            data_attributes[attribute] = kwargs[k]
 
+    if data_attributes:
+        tag_data = {**tag_data, "data_attributes": data_attributes}
     return tag_data
 
 


### PR DESCRIPTION
## 🎯 Objectif

Je propose d'ajouter le support des data-attributes, ici au composant `button` mais cela pourrait être étendu à tous les composants à terme. 

## 🔍 Implémentation

- mise à jour de la fonction `parse_tag_args` 
- si un argument est préfixé de `data_` alors il est converti au format `data-` et rendu dans le template 
- côté template, on gère ça via un filtre 

## ⚠️ Informations supplémentaires

Je ne suis pas hyper persuadé de l'approche côté templating, l'idée était d'avoir quelque chose de fonctionnel pour mon usage, mais je pense qu'il faudrait rendre cela un peu plus pratique à utiliser. 

