### PR TITLE
[4.0] Forcer l'inversion de la logique de marquage des champs requis/optionnels

### DIFF
--- a/dsfr/forms.py
+++ b/dsfr/forms.py
@@ -46,32 +46,6 @@ class DsfrBaseForm(forms.Form):
             else get_default_renderer()
         )
 
-    def get_context(self) -> dict:
-        from django.conf import settings
-
-        try:
-            mark_optional_fields = settings.DSFR_MARK_OPTIONAL_FIELDS
-            warnings.warn("""Transitional Django setting DSFR_MARK_OPTIONAL_FIELDS will be removed
-            by the next major version of django-dsfr.""")
-        except AttributeError:
-            mark_optional_fields = False
-
-        if not mark_optional_fields:
-            warnings.warn(
-                """Marking required form fields is not recommended by DSFR anymore
-                (https://www.systeme-de-design.gouv.fr/version-courante/fr/modeles/blocs-fonctionnels/formulaires#champ-obligatoire)
-                so the next major version of django-dsfr will stop doing so,
-                and mark optional fields instead.
-                To get the future behavior, you can set the transitional Django setting DSFR_MARK_OPTIONAL_FIELDS to True,
-                or you can override the DSFR_MARK_OPTIONAL_FIELDS context variable of single forms,
-                by overriding YourFormClass.get_context()""",
-                DeprecationWarning,
-            )
-
-        context = super().get_context()
-        context.setdefault("DSFR_MARK_OPTIONAL_FIELDS", mark_optional_fields)
-        return context
-
     def set_autofocus_on_first_error(self):
         """
         Sets the autofocus on the first field with an error message.

--- a/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkbox_snippet.html
@@ -3,7 +3,7 @@
   {{ field|dsfr_input_class_attr|attr:"type:checkbox" }}
   <label for="{{ field.id_for_label }}" class="fr-label">
     {# djlint:off #}
-    {{ field.label }}{% if not DSFR_MARK_OPTIONAL_FIELDS and field.field.required %}<span class="fr-required-marker" aria-hidden="true"> *</span>{% elif DSFR_MARK_OPTIONAL_FIELDS and not field.field.required %} {% translate '(Optional)' %}{% endif %}
+    {{ field.label }}{% if not field.field.required %} {% translate '(Optional)' %}{% endif %}
     {% if field.help_text %}
       <span class="fr-hint-text" id="{{ field.auto_id }}_helptext">{{ field.help_text|safe }}</span>
     {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/checkboxselectmultiple_snippet.html
@@ -5,7 +5,7 @@
   <legend class="fr-fieldset__legend fr-fieldset__legend--regular"
           id="{{ field.auto_id }}-legend">
     {# djlint:off #}
-    {{ field.label }}{% if not DSFR_MARK_OPTIONAL_FIELDS and field.field.required %}<span class="fr-required-marker" aria-hidden="true"> *</span>{% elif DSFR_MARK_OPTIONAL_FIELDS and not field.field.required %} {% translate '(Optional)' %}{% endif %}
+    {{ field.label }}{% if not field.field.required %} {% translate '(Optional)' %}{% endif %}
     {% if field.help_text %}
       <span class="fr-hint-text" id="{{ field.auto_id }}_helptext">{{ field.help_text|safe }}</span>
     {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
@@ -3,7 +3,7 @@
 <div class="{{ field.field.widget.group_class|default:'fr-input-group' }}{% if field.errors %} {{ field.field.widget.group_class|default:'fr-input-group' }}--error{% endif %}{% if field.field.disabled %} fr-input-group--disabled{% endif %}">
   <label for="{{ field.id_for_label }}" class="fr-label">
     {# djlint:off #}
-    {{ field.label }}{% if not DSFR_MARK_OPTIONAL_FIELDS and field.field.required %}<span class="fr-required-marker" aria-hidden="true"> *</span>{% elif DSFR_MARK_OPTIONAL_FIELDS and not field.field.required %} {% translate '(Optional)' %}{% endif %}
+    {{ field.label }}{% if not field.field.required %} {% translate '(Optional)' %}{% endif %}
     {% if field.help_text %}
       <span class="fr-hint-text" id="{{ field.id_for_label }}_helptext">{{ field.help_text|safe }}</span>
     {% endif %}

--- a/dsfr/templates/dsfr/form_field_snippets/numbercursor_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/numbercursor_snippet.html
@@ -3,7 +3,7 @@
 <div class="fr-range-group {% if field.errors %}fr-range-group--error{% endif %} {% if field.field.disabled %}fr-range-group--disabled{% endif %}">
   <label for="{{ field.id_for_label }}" class="fr-label">
     {# djlint:off #}
-    {{ field.label }}{% if not DSFR_MARK_OPTIONAL_FIELDS and field.field.required %}<span class="fr-required-marker" aria-hidden="true"> *</span>{% elif DSFR_MARK_OPTIONAL_FIELDS and not field.field.required %} {% translate '(Optional)' %}{% endif %}
+    {{ field.label }}{% if not field.field.required %} {% translate '(Optional)' %}{% endif %}
     {% if field.help_text %}
       <span class="fr-hint-text" id="{{ field.id_for_label }}_helptext">
         {{ field.help_text|safe }}, valeur

--- a/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/radioselect_snippet.html
@@ -5,7 +5,7 @@
   <legend class="fr-fieldset__legend fr-fieldset__legend--regular"
           id="{{ field.auto_id }}-legend">
     {# djlint:off #}
-    {{ field.label }}{% if not DSFR_MARK_OPTIONAL_FIELDS and field.field.required %}<span class="fr-required-marker" aria-hidden="true"> *</span>{% elif DSFR_MARK_OPTIONAL_FIELDS and not field.field.required %} {% translate '(Optional)' %}{% endif %}
+    {{ field.label }}{% if not field.field.required %} {% translate '(Optional)' %}{% endif %}
     {% if field.help_text %}
       <span class="fr-hint-text" id="{{ field.auto_id }}_helptext">{{ field.help_text|safe }}</span>
     {% endif %}

--- a/dsfr/test/test_form_field_snippets.py
+++ b/dsfr/test/test_form_field_snippets.py
@@ -133,61 +133,31 @@ class RequiredFieldsMarkerTestCase(SimpleTestCase):
             required=False,
         )
 
-    def test_renders_required_field_markers(self):
+    def test_renders_optional_field_markers_when_configured(self):
         rendered = Template("{{form}}").render(
             Context({"form": RequiredFieldsMarkerTestCase.DummyForm()})
         )
         self.assertInHTML(
-            """Required text field<span class="fr-required-marker" aria-hidden="true"> *</span>""",
+            """Required text field\n""",
             rendered,
         )
         self.assertInHTML(
-            """Required radio field<span class="fr-required-marker" aria-hidden="true"> *</span>""",
+            """Required radio field\n""",
             rendered,
         )
         self.assertInHTML(
-            """Required checkbox field<span class="fr-required-marker" aria-hidden="true"> *</span>""",
+            """Required checkbox field\n""",
             rendered,
         )
         self.assertInHTML(
-            """Optional text field\n""",
+            """Optional text field (Optionnel)""",
             rendered,
         )
         self.assertInHTML(
-            """Optional radio field\n""",
+            """Optional radio field (Optionnel)""",
             rendered,
         )
         self.assertInHTML(
-            """Optional checkbox field\n""",
+            """Optional checkbox field (Optionnel)""",
             rendered,
         )
-
-    def test_renders_optional_field_markers_when_configured(self):
-        with self.settings(DSFR_MARK_OPTIONAL_FIELDS=True):
-            rendered = Template("{{form}}").render(
-                Context({"form": RequiredFieldsMarkerTestCase.DummyForm()})
-            )
-            self.assertInHTML(
-                """Required text field\n""",
-                rendered,
-            )
-            self.assertInHTML(
-                """Required radio field\n""",
-                rendered,
-            )
-            self.assertInHTML(
-                """Required checkbox field\n""",
-                rendered,
-            )
-            self.assertInHTML(
-                """Optional text field (Optionnel)""",
-                rendered,
-            )
-            self.assertInHTML(
-                """Optional radio field (Optionnel)""",
-                rendered,
-            )
-            self.assertInHTML(
-                """Optional checkbox field (Optionnel)""",
-                rendered,
-            )


### PR DESCRIPTION
## 🎯 Objectif

Se mettre en conformité avec la recommandation du DSFR de marquer non pas les champs requis mais les champs optionnels.

## 🔍 Implémentation

Cette PR fait suite à #236 , qui introduisait une transition en douceur via un setting `DSFR_MARK_OPTIONAL_FIELDS`. Cette PR supprime ce setting et active ce comportement par défaut, sans possibilité de revenir à l'ancien comportement.

> [!CAUTION]
> Cette PR consiste en un breaking change, ne pas merger avant d'être sûrs qu'on va bientôt publier une nouvelle version majeure.