### PR TITLE
fix django-dsfr crashing with ImportError when optional dependency 'markdown' is absent

### DIFF
--- a/dsfr/markdown.py
+++ b/dsfr/markdown.py
@@ -1,0 +1,169 @@
+from typing import Any
+
+
+try:
+    from markdown.blockprocessors import BlockProcessor, BlockQuoteProcessor
+    from markdown.inlinepatterns import LinkInlineProcessor, LINK_RE
+    from markdown.extensions.admonition import AdmonitionProcessor
+    from markdown.extensions.tables import TableProcessor
+    from markdown.extensions.toc import TocTreeprocessor, TocExtension
+    from markdown.extensions import Extension
+    import xml.etree.ElementTree as etree
+except ImportError:
+    raise ImportError(
+        "No module named 'markdown'; to use django-dsfr's markdown features, you must install 'markdown' "
+        "optional feature by specifying 'django-dsfr[markdown]' in your requirements.txt or pyproject.toml"
+    )
+
+import re
+
+
+class DsfrTableProcessorMixin(BlockProcessor):
+    dsfr_bordered = False
+
+    def run(self, parent, *args):
+        super().run(parent, *args)
+
+        # Build the DSFR-specific layers surrounding the <table>
+        # cf https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau
+        div = etree.SubElement(parent, "div")
+        div.attrib["class"] = "fr-table"
+        if self.dsfr_bordered:
+            div.attrib["class"] += " fr-table--bordered"
+        wrapper = etree.SubElement(div, "div")
+        wrapper.attrib["class"] = "fr-table__wrapper"
+        container = etree.SubElement(wrapper, "div")
+        container.attrib["class"] = "fr-table__container"
+        content = etree.SubElement(container, "div")
+        content.attrib["class"] = "fr-table__content"
+
+        # move the table from the parent to the lowest DSFR layer
+        added_table = parent.find("table[last()]")
+        parent.remove(added_table)
+        content.append(added_table)
+
+
+class DsfrTableProcessor(DsfrTableProcessorMixin, TableProcessor):
+    pass
+
+
+class DsfrCalloutProcessor(AdmonitionProcessor):
+    CLASSNAME = "fr-callout"
+    CLASSNAME_TITLE = "fr-callout__title"
+
+    def run(self, parent: etree.Element, *args) -> None:
+        super().run(parent, *args)
+        div = parent.find("div")
+        if any(
+            (
+                dsfr_icon_suffix in div.attrib["class"]
+                for dsfr_icon_suffix in ("-line", "-fill")
+            )
+        ):
+            div.attrib["class"] = div.attrib["class"].replace(" ", " fr-icon-")
+        for child in div.findall("*"):
+            if "class" in child.attrib:
+                continue
+            child.attrib["class"] = "fr-callout__text"
+
+
+class DsfrHighlightProcessor(AdmonitionProcessor):
+    CLASSNAME = "fr-highlight"
+    RE = re.compile(r'(?:^|\n)!! ?([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
+
+    def get_class_and_title(self, match):
+        return match.group(1).lower(), None
+
+
+class DsfrQuoteProcessor(BlockQuoteProcessor):
+    def run(self, parent: etree.Element, *args):
+        super().run(parent, *args)
+        figure = etree.SubElement(parent, "figure", {"class": "fr-quote"})
+        blockquote = parent.find("blockquote")
+        parent.remove(blockquote)
+        figure.append(blockquote)
+
+
+class DsfrLinkProcessor(LinkInlineProcessor):
+    def handleMatch(self, *args):
+        el, pos, idx = super().handleMatch(*args)
+        if (
+            hasattr(el, "attrib")
+            and "href" in el.attrib
+            and (
+                el.attrib["href"].startswith("http://")
+                or el.attrib["href"].startswith("https://")
+            )
+        ):
+            el.attrib["target"] = "_blank"
+            el.attrib["rel"] = "noopener external"
+            el.attrib["title"] = f"{el.text.strip()} - nouvelle fenêtre"
+        return el, pos, idx
+
+
+class DsfrExtension(Extension):
+    def extendMarkdown(self, md):
+        md.inlinePatterns.register(DsfrLinkProcessor(LINK_RE, md), "link", 200)
+        md.parser.blockprocessors.register(
+            DsfrTableProcessor(md.parser, self.getConfigs()), "table", 100
+        )
+        md.parser.blockprocessors.register(
+            DsfrCalloutProcessor(md.parser), "dsfr-callout", 100
+        )
+        md.parser.blockprocessors.register(
+            DsfrHighlightProcessor(md.parser), "dsfr-highlight", 100
+        )
+        md.parser.blockprocessors.register(
+            DsfrQuoteProcessor(md.parser), "dsfr-quote", 100
+        )
+
+
+class DsfrTocProcessor(TocTreeprocessor):
+    def __init__(self, md, config):
+        config.update(
+            {
+                "title": "Sommaire",
+                "toc_class": "fr-summary",
+                "title_class": "fr-summary__title",
+            }
+        )
+        super().__init__(md, config)
+
+    def run(self, doc):
+        super().run(doc)
+        toc = doc.find(f"div[@class = '{self.toc_class}']")
+        toc.tag = "nav"
+        toc.attrib["role"] = "navigation"
+        toc.attrib["aria-labelledby"] = "fr-summary-title"
+        title = toc.find(f"*[@class = '{self.title_class}']")
+        title.tag = "h2"
+        title.attrib["id"] = toc.attrib["aria-labelledby"]
+        for ul in toc.findall(".//ul"):
+            ul.tag = "ol"
+        for a in toc.findall(".//a"):
+            a.attrib["class"] = "fr-summary__link"
+
+
+class DsfrTocExtension(TocExtension):
+    TreeProcessorClass = DsfrTocProcessor
+
+
+def markdown(text: str, **kwargs: Any) -> str:
+    from markdown import markdown as render
+    from markdown.extensions.attr_list import AttrListExtension
+    from markdown.extensions.nl2br import Nl2BrExtension
+    from pymdownx import striphtml
+
+    kwargs.setdefault("extensions", [])
+    kwargs["extensions"] = [
+        AttrListExtension(),
+        DsfrExtension(),
+        Nl2BrExtension(),
+        *kwargs["extensions"],
+        striphtml.__name__,
+    ]
+    from django.utils.safestring import mark_safe
+    from django.utils.html import conditional_escape
+
+    text = conditional_escape(text)
+    return mark_safe(render(text, **kwargs))

--- a/dsfr/templatetags/dsfr_md_tags.py
+++ b/dsfr/templatetags/dsfr_md_tags.py
@@ -1,178 +1,19 @@
-import re
-
 from django import template
-from django.utils.safestring import mark_safe
-from markdown import markdown
-from markdown.blockprocessors import BlockProcessor, BlockQuoteProcessor
-from markdown.inlinepatterns import LinkInlineProcessor, LINK_RE
-from markdown.extensions.admonition import AdmonitionProcessor
-from markdown.extensions.attr_list import AttrListExtension
-from markdown.extensions.nl2br import Nl2BrExtension
-from markdown.extensions.tables import TableProcessor
-from markdown.extensions.toc import TocTreeprocessor, TocExtension
-from markdown.extensions import Extension
-import xml.etree.ElementTree as etree
-
 
 register = template.Library()
 
 
-class DsfrTableProcessorMixin(BlockProcessor):
-    dsfr_bordered = False
-
-    def run(self, parent, *args):
-        super().run(parent, *args)
-
-        # Build the DSFR-specific layers surrounding the <table>
-        # cf https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau
-        div = etree.SubElement(parent, "div")
-        div.attrib["class"] = "fr-table"
-        if self.dsfr_bordered:
-            div.attrib["class"] += " fr-table--bordered"
-        wrapper = etree.SubElement(div, "div")
-        wrapper.attrib["class"] = "fr-table__wrapper"
-        container = etree.SubElement(wrapper, "div")
-        container.attrib["class"] = "fr-table__container"
-        content = etree.SubElement(container, "div")
-        content.attrib["class"] = "fr-table__content"
-
-        # move the table from the parent to the lowest DSFR layer
-        added_table = parent.find("table[last()]")
-        parent.remove(added_table)
-        content.append(added_table)
-
-
-class DsfrTableProcessor(DsfrTableProcessorMixin, TableProcessor):
-    pass
-
-
-class DsfrCalloutProcessor(AdmonitionProcessor):
-    CLASSNAME = "fr-callout"
-    CLASSNAME_TITLE = "fr-callout__title"
-
-    def run(self, parent: etree.Element, *args) -> None:
-        super().run(parent, *args)
-        div = parent.find("div")
-        if any(
-            (
-                dsfr_icon_suffix in div.attrib["class"]
-                for dsfr_icon_suffix in ("-line", "-fill")
-            )
-        ):
-            div.attrib["class"] = div.attrib["class"].replace(" ", " fr-icon-")
-        for child in div.findall("*"):
-            if "class" in child.attrib:
-                continue
-            child.attrib["class"] = "fr-callout__text"
-
-
-class DsfrHighlightProcessor(AdmonitionProcessor):
-    CLASSNAME = "fr-highlight"
-    RE = re.compile(r'(?:^|\n)!! ?([\w\-]+(?: +[\w\-]+)*)(?: +"(.*?)")? *(?:\n|$)')
-
-    def get_class_and_title(self, match):
-        return match.group(1).lower(), None
-
-
-class DsfrQuoteProcessor(BlockQuoteProcessor):
-    def run(self, parent: etree.Element, *args):
-        super().run(parent, *args)
-        figure = etree.SubElement(parent, "figure", {"class": "fr-quote"})
-        blockquote = parent.find("blockquote")
-        parent.remove(blockquote)
-        figure.append(blockquote)
-
-
-class DsfrLinkProcessor(LinkInlineProcessor):
-    def handleMatch(self, *args):
-        el, pos, idx = super().handleMatch(*args)
-        if (
-            hasattr(el, "attrib")
-            and "href" in el.attrib
-            and (
-                el.attrib["href"].startswith("http://")
-                or el.attrib["href"].startswith("https://")
-            )
-        ):
-            el.attrib["target"] = "_blank"
-            el.attrib["rel"] = "noopener external"
-            el.attrib["title"] = f"{el.text.strip()} - nouvelle fenêtre"
-        return el, pos, idx
-
-
-class DsfrExtension(Extension):
-    def extendMarkdown(self, md):
-        md.inlinePatterns.register(DsfrLinkProcessor(LINK_RE, md), "link", 200)
-        md.parser.blockprocessors.register(
-            DsfrTableProcessor(md.parser, self.getConfigs()), "table", 100
-        )
-        md.parser.blockprocessors.register(
-            DsfrCalloutProcessor(md.parser), "dsfr-callout", 100
-        )
-        md.parser.blockprocessors.register(
-            DsfrHighlightProcessor(md.parser), "dsfr-highlight", 100
-        )
-        md.parser.blockprocessors.register(
-            DsfrQuoteProcessor(md.parser), "dsfr-quote", 100
-        )
-
-
-class DsfrTocProcessor(TocTreeprocessor):
-    def __init__(self, md, config):
-        config.update(
-            {
-                "title": "Sommaire",
-                "toc_class": "fr-summary",
-                "title_class": "fr-summary__title",
-            }
-        )
-        super().__init__(md, config)
-
-    def run(self, doc):
-        super().run(doc)
-        toc = doc.find(f"div[@class = '{self.toc_class}']")
-        toc.tag = "nav"
-        toc.attrib["role"] = "navigation"
-        toc.attrib["aria-labelledby"] = "fr-summary-title"
-        title = toc.find(f"*[@class = '{self.title_class}']")
-        title.tag = "h2"
-        title.attrib["id"] = toc.attrib["aria-labelledby"]
-        for ul in toc.findall(".//ul"):
-            ul.tag = "ol"
-        for a in toc.findall(".//a"):
-            a.attrib["class"] = "fr-summary__link"
-
-
-class DsfrTocExtension(TocExtension):
-    TreeProcessorClass = DsfrTocProcessor
-
-
 @register.filter(is_safe=True)
 def dsfr_md(content: str) -> str:
-    return mark_safe(
-        markdown(
-            content,
-            extensions=[
-                AttrListExtension(),
-                DsfrExtension(),
-                Nl2BrExtension(),
-                "pymdownx.striphtml",
-            ],
-        )
-    )
+    from dsfr.markdown import markdown
+
+    return markdown(content)
 
 
 @register.filter(is_safe=True)
 def dsfr_md_with_toc(content: str) -> str:
-    return mark_safe(
-        markdown(
-            content,
-            extensions=[
-                AttrListExtension(),
-                DsfrExtension(),
-                DsfrTocExtension(),
-                Nl2BrExtension(),
-                "pymdownx.striphtml",
-            ],
-        )
-    )
+    from dsfr.markdown import markdown
+    from dsfr.markdown import DsfrTocExtension
+
+    return  markdown(content,extensions=[DsfrTocExtension()])
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ build-backend = "hatchling.build"
 markdown = [
   "markdown ~=3.10",
   "pymdown-extensions ~=10.20",
+  "lxml>=6.0.1",
 ]
 
 [dependency-groups]
@@ -67,7 +68,6 @@ dev = [
     "markdown>=3.10",
     "pygments>=2.19.2",
     "beautifulsoup4>=4.13.5",
-    "lxml>=6.0.1",
     "setuptools>=80.9.0",
     "twine>=6.1.0",
     "rust-just>=1.42.4",


### PR DESCRIPTION
## 🎯 Objectif

La dernière release fait crasher un projet Django si le paquet `markdown` n'est pas installé, ce qui est logique parce que `dsfr/templatetags/dsfr_md_tags.py` est automatiquement importé par Django donc les imports sont exécutés. Cette PR rend les imports lazy avec un message clair si la personne tente d'utiliser le template tag.
