### PR TITLE
[Composant Quote] Pouvoir choisir la taille du texte cité

### DIFF
--- a/dsfr/templates/dsfr/quote.html
+++ b/dsfr/templates/dsfr/quote.html
@@ -2,7 +2,7 @@
 {% translate "Opens a new window" as new_window_label %}
 <figure class="fr-quote fr-quote--column{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}">
   <blockquote {% if self.source_url %}cite="{{ self.source_url }}"{% endif %}>
-    <p>
+    <p class="fr-text--{{ self.text_size }}">
       {{ self.text }}
     </p>
   </blockquote>

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -928,6 +928,7 @@ def dsfr_quote(*args, **kwargs) -> dict:
     ```python
     data_dict = {
         "text": "Text of the quote",
+        "text_size": "(Optional) The size of the quote text (values: 'md', 'lg', 'xl') ; defaults to 'md'",
         "source_url": "(Optional) URL of the source of the quote",
         "author": "(Optional) The author of the quote",
         "source": "(Optional) The name of the source of the quote",
@@ -954,6 +955,7 @@ def dsfr_quote(*args, **kwargs) -> dict:
 
     allowed_keys = [
         "text",
+        "text_size",
         "source_url",
         "author",
         "source",
@@ -962,6 +964,10 @@ def dsfr_quote(*args, **kwargs) -> dict:
         "extra_classes",
     ]
     tag_data = parse_tag_args(args, kwargs, allowed_keys)
+
+    text_size_options = ("md", "lg", "xl")
+    if tag_data.get("text_size", "") not in text_size_options:
+        tag_data["text_size"] = text_size_options[0]
 
     return {"self": tag_data}
 

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -874,13 +874,40 @@ class DsfrQuoteTagTest(SimpleTestCase):
     context = Context({"test_data": test_data})
     template_to_render = Template("{% load dsfr_tags %} {% dsfr_quote test_data %}")
 
-    def test_quote_tag_rendered(self):
+    def test_quote_tag_default_rendered(self):
         rendered_template = self.template_to_render.render(self.context)
         self.assertInHTML(
             """
             <figure class="fr-quote fr-quote--column">
                 <blockquote cite="https://www.systeme-de-design.gouv.fr/">
-                    <p>Développer vos sites et applications en utilisant des composants prêts à l&#x27;emploi, accessibles et ergonomiques</p>
+                    <p class="fr-text--md">Développer vos sites et applications en utilisant des composants prêts à l&#x27;emploi, accessibles et ergonomiques</p>
+                </blockquote>
+                <figcaption>
+                    <p class="fr-quote__author">Auteur</p>
+                    <ul class="fr-quote__source">
+                    <li>
+                        <cite>Système de Design de l&#x27;État</cite>
+                    </li>
+                    <li>Détail sans lien</li>
+                    <li><a target="_blank" rel="noopener noreferrer" href="https://template.incubateur.net/">Détail avec lien <span class="fr-sr-only">Ouvre une nouvelle fenêtre</span></a></li>
+                    </ul>
+                    <div class="fr-quote__image">
+                    <img src="https://via.placeholder.com/150x150" class="fr-responsive-img" alt="" />
+                    </div>
+                </figcaption>
+            </figure>
+            """,  # noqa
+            rendered_template,
+        )
+
+    def test_quote_tag_text_size_rendered(self):
+        self.context["test_data"]["text_size"] = "lg"
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """
+            <figure class="fr-quote fr-quote--column">
+                <blockquote cite="https://www.systeme-de-design.gouv.fr/">
+                    <p class="fr-text--lg">Développer vos sites et applications en utilisant des composants prêts à l&#x27;emploi, accessibles et ergonomiques</p>
                 </blockquote>
                 <figcaption>
                     <p class="fr-quote__author">Auteur</p>

--- a/example_app/dsfr_components.py
+++ b/example_app/dsfr_components.py
@@ -672,6 +672,10 @@ IMPLEMENTED_COMPONENTS = {
                 "text": "« Citation très basique, sans aucun des champs optionnels. »",
             },
             {
+                "text": "« Citation basique en grande taille. »",
+                "text_size": "lg",
+            },
+            {
                 "text": "« Développer vos sites et applications en utilisant des composants prêts à l’emploi, accessibles et ergonomiques »",
                 "source_url": "https://www.systeme-de-design.gouv.fr/",
                 "author": "Auteur",


### PR DESCRIPTION
## 🎯 Objectif

Nouvelle fonctionnalité, pour correspondre à ce qui est montré dans [la démo officielle du composant Citation](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/citation/demonstration-de-la-citation) : pouvoir choisir la taille du texte entre `md`, `lg` ou `xl`. Évidemment c'est optionnel et la taille par défaut est `md`.

## 🔍 Implémentation

- Ajout de l'option au templatetag
- Contrôle de validité de la valeur et forçage à `md` si vide ou valeur invalide
- Ajout de la classe CSS DSFR correspondante au HTML
- Documentation dans le site d'example