### PR TITLE
Correctif sur les exigences de l'app dsfr.extras.markdown

### DIFF
--- a/dsfr/extras/markdown/apps.py
+++ b/dsfr/extras/markdown/apps.py
@@ -8,7 +8,7 @@ class DsfrMarkdownConfig(AppConfig):
     name = "dsfr.extras.markdown"
 
     def ready(self):
-        for dep in ("markdown", "pymdownx", "lxml"):
+        for dep in ("markdown", "pymdownx"):
             if find_spec(dep) is None:
                 raise ImportError(
                     f"No module named {dep}; to use django-dsfr's markdown features, you must install the 'markdown' feature by specifying 'django-dsfr[markdown]' in your requirements.txt or pyproject.toml"

--- a/dsfr/extras/markdown/templatetags/dsfr_md_tags.py
+++ b/dsfr/extras/markdown/templatetags/dsfr_md_tags.py
@@ -1,4 +1,5 @@
 import re
+import xml.etree.ElementTree as etree
 
 from django import template
 from django.utils.safestring import mark_safe
@@ -11,7 +12,6 @@ from markdown.extensions.nl2br import Nl2BrExtension
 from markdown.extensions.tables import TableProcessor
 from markdown.extensions.toc import TocTreeprocessor, TocExtension
 from markdown.extensions import Extension
-import xml.etree.ElementTree as etree
 
 
 register = template.Library()


### PR DESCRIPTION
## 🎯 Objectif

La mise à jour vers `django-dsfr` 3.4.1 casse si le projet qui en dépend a besoin de `dsfr.extras.markdown` mais n'a pas `lxml` dans ses dépendances (cf [la CI d'Aides Agri](https://github.com/betagouv/aides-agri/actions/runs/24657596027/job/72094945313?pr=490)). Pourtant, `dsfr.extras.markdown` ne dépend pas vraiment de `lxml`, car la classe `xml.etree.ElementTree` est native à Python (cf [la doc](https://docs.python.org/3/library/xml.etree.elementtree.html)).

## 🔍 Implémentation

Cette PR :

- Supprime cette exigence codée en dur ;
- Réordonne les imports pour qu'il soit plus immédiat de comprendre que cet import concerne une classe native de Python et non pas une version issue de la lib `lxml`