### PR TITLE
Préparation de la release 3.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-dsfr"
-version = "3.4.1"
+version = "3.4.2"
 description = "Integrate the French government Design System into a Django app"
 authors = [{ name = "Sylvain Boissel", email = "sylvain.boissel@beta.gouv.fr" }]
 requires-python = "<4.0,>=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/19/c8/ece20c91129314a1e
 
 [[package]]
 name = "django-dsfr"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## 🎯 Objectif

Sortir rapidement la 3.4.2 pour que la 3.4.x soit enfin viable pour nos projets.

## 🔍 Implémentation

```bash
just prepare_release patch
```