### PR TITLE
Allow to specify the remote repo name when running 'just prepare_release'

### DIFF
--- a/justfile
+++ b/justfile
@@ -89,7 +89,7 @@ upgrade:
 
 # Prepare a new release
 [arg('bump', pattern='major|minor|patch')]
-prepare_release bump:
+prepare_release bump repo_name='origin':
     #!/usr/bin/env bash
 
     set -e
@@ -100,4 +100,4 @@ prepare_release bump:
     uv version "$version"
     git add pyproject.toml uv.lock
     git commit -m "chore: prepare release $version"
-    git push -u origin "release/$version"
+    git push -u {{repo_name}} "release/$version"


### PR DESCRIPTION
## 🎯 Objectif

Je travaille sur un fork donc quand je dois release ici le nom du repo, c'est `upstream` et pas `origin`.