### PR TITLE
Hidden field are not correctly rendered with `dsfr_form_field` refacto

### DIFF
--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -1667,7 +1667,7 @@ def dsfr_form_field(field: BoundField) -> str:
             stacklevel=3,
         )
 
-    return field.as_field_group()
+    return field.as_hidden() if field.is_hidden else field.as_field_group()
 
 
 register.filter(name="dsfr_input_class_attr", filter_func=dsfr_input_class_attr)
@@ -1777,7 +1777,8 @@ def dsfr_form(context: Context):
 def dsfr_mark_optionnal_fields(bf):
     mark_optional_fields = getattr(settings, "DSFR_MARK_OPTIONAL_FIELDS", False)
     if bf.field.required and not mark_optional_fields:
-        return mark_safe(
+
+        return mark_safe(  # nosec B308
             '<span class="fr-required-marker" aria-hidden="true"> *</span>'
         )
     elif not bf.field.required and mark_optional_fields:

--- a/dsfr/test/test_fields.py
+++ b/dsfr/test/test_fields.py
@@ -19,6 +19,9 @@ class FormFieldTestCase(SimpleTestCase):
                 }
             ),
         )
+        user_name_hidden = forms.CharField(
+            label="Nom d’utilisateur", max_length=100, widget=forms.HiddenInput
+        )
 
     def test_full_form_works(self):
         rendered = Template("{{form}}").render(
@@ -31,6 +34,15 @@ class FormFieldTestCase(SimpleTestCase):
             "{% load dsfr_tags %}{% dsfr_form_field form.user_name %}"
         ).render(Context({"form": FormFieldTestCase.DummyForm()}))
         self.assertIn("Nom d’utilisateur", rendered)
+
+    def test_correct_hidden_field_works(self):
+        rendered = Template(
+            "{% load dsfr_tags %}{% dsfr_form_field form.user_name_hidden %}"
+        ).render(Context({"form": FormFieldTestCase.DummyForm()}))
+        self.assertHTMLEqual(
+            '<input id="id_user_name_hidden" name="user_name_hidden" type="hidden">',
+            rendered,
+        )
 
     def test_incorrect_field_raises_error(self):
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
Commit #254 refactored forms to use Django's form rendering API instead of custom 'dsfr/form_field_snippets/field_snippet.html' template. 'dsfr_form_field' tag was preseved for compatibility but behavior on hidden fields was left out by mistake. This PR solves this.