### PR TITLE
Fix DsfrBoundField not rendering checkboxes correctly because of undetected `widget_type`

### DIFF
--- a/dsfr/forms.py
+++ b/dsfr/forms.py
@@ -44,7 +44,7 @@ class DsfrBoundField(forms.BoundField):
             return template_name
 
         match self.widget_type:
-            case "checkboxinput":
+            case "checkbox":
                 return "dsfr/form_field_snippets/checkbox_snippet.html"
             case "checkboxselectmultiple" | "inlinecheckboxselectmultiple":
                 return "dsfr/form_field_snippets/checkboxselectmultiple_snippet.html"

--- a/dsfr/templates/django/forms/widgets/radio_option.html
+++ b/dsfr/templates/django/forms/widgets/radio_option.html
@@ -1,6 +1,4 @@
-{% if widget.attrs.dsfr == "dsfr" %}
-  <div class="fr-radio-group">
-  {% endif %}
+<div class="fr-radio-group">
   {% include "django/forms/widgets/input.html" %}
   {% if widget.wrap_label %}
     <label class="fr-label"
@@ -13,6 +11,4 @@
       {% endif %}
     </label>
   {% endif %}
-  {% if widget.attrs.dsfr == "dsfr" %}
-  </div>
-{% endif %}
+</div>

--- a/dsfr/test/test_forms.py
+++ b/dsfr/test/test_forms.py
@@ -3,8 +3,15 @@ from typing import NoReturn
 from django import forms
 from django.test import SimpleTestCase
 
-
+from dsfr.enums import RichRadioButtonChoices
 from dsfr.forms import DsfrBaseForm
+from dsfr.widgets import (
+    InlineCheckboxSelectMultiple,
+    InlineRadioSelect,
+    RichRadioSelect,
+    NumberCursor,
+    SegmentedControl,
+)
 
 
 class DsfrBaseFormTestCase(SimpleTestCase):
@@ -52,3 +59,178 @@ class DsfrBaseFormTestCase(SimpleTestCase):
         with self.assertRaises(self.failureException):
             # is_valid should trigger validation
             AssertForm(data={}).is_valid()
+
+
+class WidgetsTest(DsfrBaseFormTestCase):
+    maxDiff = None
+
+    def _create_form_with_widget(
+        self, widget: forms.Widget | type[forms.Widget]
+    ) -> DsfrBaseForm:
+        klass = type(
+            f"{widget.__class__.__name__}Form",
+            (DsfrBaseForm,),
+            {"input": forms.Field(widget=widget)},
+        )
+        return klass()
+
+    def _create_form_with_fields(self, fields: dict[str, forms.Field]) -> DsfrBaseForm:
+        return type("TestForm", (DsfrBaseForm,), fields)()
+
+    def test_template_name(self):
+        form = self._create_form_with_widget(forms.CheckboxInput)
+        self.assertEqual(
+            "dsfr/form_field_snippets/checkbox_snippet.html",
+            form["input"].template_name,
+        )
+
+        form = self._create_form_with_widget(forms.CheckboxSelectMultiple)
+        self.assertEqual(
+            "dsfr/form_field_snippets/checkboxselectmultiple_snippet.html",
+            form["input"].template_name,
+        )
+
+        form = self._create_form_with_widget(InlineCheckboxSelectMultiple)
+        self.assertEqual(
+            "dsfr/form_field_snippets/checkboxselectmultiple_snippet.html",
+            form["input"].template_name,
+        )
+
+        form = self._create_form_with_widget(forms.RadioSelect)
+        self.assertEqual(
+            "dsfr/form_field_snippets/radioselect_snippet.html",
+            form["input"].template_name,
+        )
+
+        form = self._create_form_with_widget(InlineRadioSelect)
+        self.assertEqual(
+            "dsfr/form_field_snippets/radioselect_snippet.html",
+            form["input"].template_name,
+        )
+
+        class ExampleRichChoices(RichRadioButtonChoices):
+            pass
+
+        form = self._create_form_with_widget(
+            RichRadioSelect(extended_choices=ExampleRichChoices)
+        )
+        self.assertEqual(
+            "dsfr/form_field_snippets/richradioselect_snippet.html",
+            form["input"].template_name,
+        )
+
+        form = self._create_form_with_widget(NumberCursor)
+        self.assertEqual(
+            "dsfr/form_field_snippets/numbercursor_snippet.html",
+            form["input"].template_name,
+        )
+
+        form = self._create_form_with_widget(
+            SegmentedControl(extended_choices=ExampleRichChoices)
+        )
+        self.assertEqual(
+            "dsfr/form_field_snippets/segmented_control_snippet.html",
+            form["input"].template_name,
+        )
+
+    def test_render_checkbox(self):
+        # language=html
+        html = """
+            <div class="fr-checkbox-group fr-mb-2w">
+                <input type="checkbox" id="id_storybook" name="storybook" required>
+                <label class="fr-label" for="id_storybook">
+                    libellé radio<span aria-hidden="true" class="fr-required-marker">*</span>
+                </label>
+            </div>
+        """
+
+        form = self._create_form_with_fields(
+            {"storybook": forms.BooleanField(label="libellé radio")}
+        )
+        self.assertHTMLEqual(html, form["storybook"].as_field_group())
+
+    def test_render_checkbox_multiple(self):
+        # language=html
+        html = """
+            <fieldset class="fr-fieldset fr-fieldsets" id="checkboxes-id_storybook" aria-labelledby="id_storybook-legend">
+              <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="id_storybook-legend">
+                  Légende pour l’ensemble des éléments<span aria-hidden="true" class="fr-required-marker">*</span>
+              </legend>
+              <div class="fr-fieldset__element">
+                <div class="fr-checkbox-group">
+                  <input dsfr="dsfr" name="storybook" id="id_storybook_0" type="checkbox" value="checkbox1">
+                  <label class="fr-label" for="id_storybook_0"> Checkbox 1 </label>
+                </div>
+              </div>
+              <div class="fr-fieldset__element">
+                <div class="fr-checkbox-group">
+                  <input dsfr="dsfr" name="storybook" id="id_storybook_1" type="checkbox" value="checkbox2">
+                  <label class="fr-label" for="id_storybook_1"> Checkbox 2 </label>
+                </div>
+              </div>
+              <div class="fr-fieldset__element">
+                <div class="fr-checkbox-group">
+                  <input dsfr="dsfr" name="storybook" id="id_storybook_2" type="checkbox" value="checkbox3">
+                  <label class="fr-label" for="id_storybook_2"> Checkbox 3 </label>
+                </div>
+              </div>
+            </fieldset>
+        """
+
+        form = self._create_form_with_fields(
+            {
+                "storybook": forms.ChoiceField(
+                    label="Légende pour l’ensemble des éléments",
+                    choices=(
+                        ("checkbox1", "Checkbox 1"),
+                        ("checkbox2", "Checkbox 2"),
+                        ("checkbox3", "Checkbox 3"),
+                    ),
+                    widget=forms.CheckboxSelectMultiple,
+                )
+            }
+        )
+        self.assertHTMLEqual(html, form["storybook"].as_field_group())
+
+    def test_render_select_multiple(self):
+        # language=html
+        html = """
+               <fieldset class="fr-fieldset" id="radio-id_storybook" aria-labelledby="id_storybook-legend">
+                   <legend class="fr-fieldset__legend--regular fr-fieldset__legend" id="id_storybook-legend">
+                       Légende pour l’ensemble des éléments<span aria-hidden="true" class="fr-required-marker">*</span>
+                   </legend>
+                   <div class="fr-fieldset__element">
+                       <div class="fr-radio-group">
+                           <input dsfr="dsfr" type="radio" id="id_storybook_0" name="storybook" value="radio1" required>
+                           <label class="fr-label" for="id_storybook_0"> Radio 1 </label>
+                       </div>
+                   </div>
+                   <div class="fr-fieldset__element">
+                       <div class="fr-radio-group">
+                           <input dsfr="dsfr" type="radio" id="id_storybook_1" name="storybook" value="radio2" required>
+                           <label class="fr-label" for="id_storybook_1"> Radio 2 </label>
+                       </div>
+                   </div>
+                   <div class="fr-fieldset__element">
+                       <div class="fr-radio-group">
+                           <input dsfr="dsfr" type="radio" id="id_storybook_2" name="storybook" value="radio3" required>
+                           <label class="fr-label" for="id_storybook_2"> Radio 3 </label>
+                       </div>
+                   </div>
+               </fieldset> \
+               """
+
+        form = self._create_form_with_fields(
+            {
+                "storybook": forms.ChoiceField(
+                    label="Légende pour l’ensemble des éléments",
+                    choices=(
+                        ("radio1", "Radio 1"),
+                        ("radio2", "Radio 2"),
+                        ("radio3", "Radio 3"),
+                    ),
+                    widget=forms.RadioSelect,
+                )
+            }
+        )
+        self.assertHTMLEqual(html, form["storybook"].as_field_group())

--- a/dsfr/widgets.py
+++ b/dsfr/widgets.py
@@ -250,6 +250,6 @@ class Toggle(CheckboxInput):
 
         css_classes = [
             self.dsfr_input_class,
-            *re.split("\s+", self.attrs.get("class", "")),
+            *re.split(r"\s+", self.attrs.get("class", "")),
         ]
         self.attrs["class"] = " ".join(dict.fromkeys(css_classes, "").keys()).strip()


### PR DESCRIPTION
## 🎯 Objectif

Je ne sais pas si c'est une régression de #254 comme l'était #316 ou si ça a toujours été là mais `DsfrBoundField.as_field_group()` ne rendait pas correctement les checkbox parce que `DsfrBoundField.widget_type == "checkbox"` et pas `checkboxinput`. À la place, il utilisait `dsfr/form_field_snippets/input_snippet.html` et, donc, les mauvaise classes DSFR.

Cette PR rajoute aussi quelques tests pour empêcher ce genre de régression. Il faudra prendre du temps pour généraliser ces tests pour plus de widgets à l'avenir surtout au moment d'intégrer les labels à l'API de rendu des formulaires Django.
