### PR TITLE
build: exclude the test package from the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ include = [
     "README.md",
     "dsfr/static/dsfr/dist/*/*.*",
 ]
+exclude = [
+    "dsfr/test",
+]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
Closes #289

Le sous-paquet `dsfr/test` était inclus dans le wheel : installer `django-dsfr` plaçait donc un paquet `dsfr.test` dans le `site-packages`. Il n'est pas utilisé à l'exécution (aucun module livré ne l'importe) et peut prêter à confusion, comme indiqué dans l'issue.

Cette PR ajoute une règle `exclude` à la cible wheel de Hatch pour ne plus livrer `dsfr/test`. Les tests restent dans l'arborescence des sources et continuent de tourner normalement avec `just test` ; ils ne sont simplement plus installés.

### Vérification

- Avant : le wheel contient 9 fichiers `dsfr/test/`
- Après : 0 fichier `dsfr/test/`, les autres modules (`dsfr/forms.py`, les assets statiques, etc.) restent présents (1718 -> 1709 fichiers)
- Après installation du wheel construit : `import dsfr` et `dsfr.forms` fonctionnent, et `dsfr.test` n'est plus importable

Le `sdist` n'est volontairement pas modifié, pour que les tests restent disponibles dans la distribution source. Je peux aussi les exclure du sdist si vous le préférez.
