### PR TITLE
fix: prevent layout shift when skip links receive focus

### DIFF
--- a/dsfr/static/css/dsfr-django-overrides.css
+++ b/dsfr/static/css/dsfr-django-overrides.css
@@ -1,3 +1,12 @@
+/* Fix: keep skiplinks in absolute position on focus to avoid pushing page content down */
+.fr-skiplinks:focus-within {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+}
+
 .errorlist {
   margin-top: 1rem;
 }

--- a/dsfr/static/dsfr/dist/component/skiplink/README.md
+++ b/dsfr/static/dsfr/dist/component/skiplink/README.md
@@ -25,4 +25,4 @@ Afin d’utiliser le composant `skiplink`, il est nécessaire d’ajouter les fi
 
 ## Documentation
 
-Consulter [la documentation](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/lien-d-evitement) sur le module Liens d'évitement
+Consulter [la documentation](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/liens-d-evitement) sur le module Liens d'évitement


### PR DESCRIPTION
## Problème

Le CSS upstream du DSFR passe `.fr-skiplinks` de `position: absolute` à `position: relative` sur `:focus-within`. Cela fait entrer le bandeau dans le flux normal du document, poussant tout le contenu de la page vers le bas au moment où un lien d'évitement reçoit le focus. Quand le focus est perdu, le bandeau repasse en `absolute` et le contenu remonte — mais le scroll reste décalé.

Le tout en image :
https://github.com/user-attachments/assets/b7640c01-1c2b-459a-9dee-72f1fcd11442


## Solution

Ajout d'un override dans `dsfr-django-overrides.css` pour forcer `position: fixed` sur `.fr-skiplinks:focus-within`, avec `top: 0`, `left: 0`, `right: 0` et un `z-index` élevé. Le bandeau s'affiche ainsi par-dessus le contenu sans décaler le layout.

## Autres changements

- Correction de l'URL de documentation du composant skiplink dans son README (`lien-d-evitement` → `liens-d-evitement`).

## Test

Tabulation sur une page utilisant le composant `{% dsfr_skiplinks %}` : le bandeau apparaît en haut sans décaler le contenu, et le scroll reste stable après perte du focus.