### PR TITLE
Contrôler via un setting l'échappement dans les composants avant déprécation

### DIFF
--- a/dsfr/templates/dsfr/accordion.html
+++ b/dsfr/templates/dsfr/accordion.html
@@ -1,3 +1,5 @@
+{% load dsfr_tags %}
+
 <section class="fr-accordion">
   <{{ self.heading_tag | default:"h3" }} class="fr-accordion__title">
   <button type="button"
@@ -8,6 +10,6 @@
   </button>
   </{{ self.heading_tag | default:"h3" }}>
   <div class="fr-collapse" id="{{ self.id }}">
-    {{ self.content | safe }}
+    {{ self.content | dsfr_maybe_safe }}
   </div>
 </section>

--- a/dsfr/templates/dsfr/alert.html
+++ b/dsfr/templates/dsfr/alert.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n dsfr_tags %}
 {% translate "Hide message" as hide_message %}
 <div role="alert"
      class="fr-alert fr-alert--{{ self.type }}{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}">
@@ -7,13 +7,13 @@
   {% endif %}
   {% if self.content %}
     <p>
-      {{ self.content | safe }}
+      {{ self.content | dsfr_maybe_safe }}
     </p>
   {% endif %}
   {% if self.is_collapsible %}
     <button class="fr-btn--close fr-btn"
             title="{{ hide_message }}"
-            {% for attr, value in self.collapsible_attrs.items %}{{ attr }}="{{ value|safe }}"{% endfor %}>
+            {% for attr, value in self.collapsible_attrs.items %}{{ attr }}="{{ value|dsfr_maybe_safe }}"{% endfor %}>
       {{ hide_message }}
     </button>
   {% endif %}

--- a/dsfr/templates/dsfr/consent.html
+++ b/dsfr/templates/dsfr/consent.html
@@ -1,11 +1,11 @@
-{% load i18n %}
+{% load i18n dsfr_tags %}
 <div class="fr-consent-banner">
   <h2 class="fr-h6">
     {{ self.title }}
   </h2>
   <div class="fr-consent-banner__content">
     <p class="fr-text--sm">
-      {{ self.content|safe }}
+      {{ self.content|dsfr_maybe_safe }}
     </p>
   </div>
   <ul class="fr-consent-banner__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">

--- a/dsfr/templates/dsfr/content.html
+++ b/dsfr/templates/dsfr/content.html
@@ -8,7 +8,7 @@
            src="{{ self.image_url }}"
            alt="{{ self.alt_text }}" />
     {% elif self.svg %}
-      {{ self.svg|safe }}
+      {{ self.svg|dsfr_maybe_safe }}
     {% elif self.iframe %}
       <iframe title="{{ self.iframe.title }}"
               class="fr-responsive-vid{% if self.ratio_class %} {{ self.ratio_class }}{% endif %}"
@@ -22,7 +22,7 @@
   </div>
   {% if self.caption %}
     <figcaption class="fr-content-media__caption">
-      {{ self.caption|safe }}
+      {{ self.caption|dsfr_maybe_safe }}
     </figcaption>
   {% endif %}
 </figure>

--- a/dsfr/templates/dsfr/highlight.html
+++ b/dsfr/templates/dsfr/highlight.html
@@ -1,5 +1,7 @@
+{% load dsfr_tags %}
+
 <div class="fr-highlight{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}">
   <p {% if self.size_class %}class="{{ self.size_class }}"{% endif %}>
-    {{ self.content | safe }}
+    {{ self.content | dsfr_maybe_safe }}
   </p>
 </div>

--- a/dsfr/templates/dsfr/notice.html
+++ b/dsfr/templates/dsfr/notice.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n dsfr_tags %}
 {% translate "Hide message" as hide_message %}
 {% translate "Consultation link" as consultation_link %}
 {% translate "Opens a new window" as new_window_label %}
@@ -6,9 +6,9 @@
   <div class="fr-container">
     <div class="fr-notice__body">
       <p>
-        <span class="fr-notice__title{% if self.icon %} {{ self.icon }}{% endif %}">{{ self.title|safe }}</span>
+        <span class="fr-notice__title{% if self.icon %} {{ self.icon }}{% endif %}">{{ self.title|dsfr_maybe_safe }}</span>
         {% if self.description %}
-          <span class="fr-notice__desc">{{ self.description|safe }}</span>
+          <span class="fr-notice__desc">{{ self.description|dsfr_maybe_safe }}</span>
         {% endif %}
         {% if self.link %}
           <a target="_blank"

--- a/dsfr/templates/dsfr/table.html
+++ b/dsfr/templates/dsfr/table.html
@@ -1,3 +1,5 @@
+{% load dsfr_tags %}
+
 <div class="fr-table{% if self.extra_classes %} {{ self.extra_classes }}{% endif %}">
   <div class="fr-table__wrapper">
     <div class="fr-table__container">
@@ -9,7 +11,7 @@
               <tr>
                 {% for cell in self.header %}
                   <th scope="col">
-                    {{ cell|safe }}
+                    {{ cell|dsfr_maybe_safe }}
                   </th>
                 {% endfor %}
               </tr>
@@ -20,7 +22,7 @@
               <tr>
                 {% for cell in row %}
                   <td>
-                    {{ cell|safe }}
+                    {{ cell|dsfr_maybe_safe }}
                   </td>
                 {% endfor %}
               </tr>

--- a/dsfr/templates/dsfr/transcription.html
+++ b/dsfr/templates/dsfr/transcription.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n dsfr_tags %}
 {% translate "Transcript" as transcript_label %}
 <div class="fr-transcription">
   <button class="fr-transcription__btn"
@@ -39,7 +39,7 @@
                     class="fr-modal__title">
                   {{ self.title|default:transcript_label }}
                 </h2>
-                {{ self.content|safe }}
+                {{ self.content|dsfr_maybe_safe }}
               </div>
             </div>
           </div>

--- a/dsfr/templatetags/dsfr_tags.py
+++ b/dsfr/templatetags/dsfr_tags.py
@@ -8,6 +8,7 @@ from django.contrib.messages.constants import DEBUG, INFO, SUCCESS, WARNING, ERR
 from django.core.paginator import Page
 from django.forms import BoundField
 from django.template import Template
+from django.template.defaultfilters import stringfilter
 from django.template.context import Context
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
@@ -1785,3 +1786,11 @@ def dsfr_mark_optionnal_fields(bf):
         return f" {_('(Optional)')}"
 
     return ""
+
+
+# Deprecated tags
+@register.filter
+@stringfilter
+def dsfr_maybe_safe(value: str):
+    content_is_safe = getattr(settings, "DSFR_CONTENT_IS_SAFE", True)
+    return mark_safe(value) if content_is_safe else value  # nosec B308 B703

--- a/dsfr/test/test_templatetags.py
+++ b/dsfr/test/test_templatetags.py
@@ -165,6 +165,23 @@ class DsfrAccordionTagTest(SimpleTestCase):
             rendered_template,
         )
 
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_accordion_tag_rendered_unsafe(self):
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """
+            <section class="fr-accordion">
+                <h3 class="fr-accordion__title">
+                    <button type="button" class="fr-accordion__btn" aria-expanded="false" aria-controls="sample-accordion">Title of the accordion item</button>
+                </h3>
+                <div class="fr-collapse" id="sample-accordion">
+                    &lt;p&gt;&lt;b&gt;Bold&lt;/b&gt; and &lt;em>emphatic&lt;/em&gt; Example content&lt;/p&gt;
+                </div>
+            </section>
+            """,  # noqa
+            rendered_template,
+        )
+
 
 class DsfrAccordionGroupTagTest(SimpleTestCase):
     test_data = [
@@ -203,7 +220,7 @@ class DsfrAlertTagTest(SimpleTestCase):
     test_data = {
         "title": "Sample title",
         "type": "info",
-        "content": "Sample content",
+        "content": "Sample <b>bold</b> content",
         "heading_tag": "h3",
         "is_collapsible": True,
         "id": "test-alert-message",
@@ -214,7 +231,14 @@ class DsfrAlertTagTest(SimpleTestCase):
 
     def test_alert_tag_rendered(self):
         rendered_template = self.template_to_render.render(self.context)
-        self.assertInHTML("""<p>Sample content</p>""", rendered_template)
+        self.assertInHTML("""<p>Sample <b>bold</b> content</p>""", rendered_template)
+
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_alert_tag_rendered_unsafe(self):
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """<p>Sample &lt;b&gt;bold&lt;/b&gt; content</p>""", rendered_template
+        )
 
     def test_alert_tag_heading_can_be_set(self):
         rendered_template = self.template_to_render.render(self.context)
@@ -581,11 +605,58 @@ class DsfrConsentTagTest(SimpleTestCase):
             rendered_template,
         )
 
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_consent_tag_rendered_unsafe(self):
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """
+        <div class="fr-consent-banner">
+        <h2 class="fr-h6">
+            À propos des cookies sur Django-DSFR
+        </h2>
+        <div class="fr-consent-banner__content">
+            <p class="fr-text--sm">
+                Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et les
+                services disponibles sur ce site. Pour en savoir plus, visitez la page &lt;a href="#"&gt;
+                Données personnelles et cookies&lt;/a&gt;. Vous pouvez, à tout moment, avoir le contrôle
+                sur les cookies que vous souhaitez activer.
+            </p>
+        </div>
+        <ul class="fr-consent-banner__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">
+            <li>
+            <button class="fr-btn"
+                    id="consent-accept-all"
+                    title="Autoriser tous les cookies">
+                Tout accepter
+            </button>
+            </li>
+            <li>
+            <button class="fr-btn"
+                    id="consent-reject-all"
+                    title="Refuser tous les cookies">
+                Tout refuser
+            </button>
+            </li>
+            <li>
+            <button class="fr-btn fr-btn--secondary"
+                    id="consent-customize"
+                    data-fr-opened="false"
+                    aria-controls="fr-consent-modal"
+                    title="Personnaliser les cookies">
+                Personnaliser
+            </button>
+            </li>
+        </ul>
+        </div>
+        """,
+            rendered_template,
+        )
+
 
 class DsfrContentTagTest(SimpleTestCase):
     test_data = {
         "alt_text": "Silhouette stylisée représentant le soleil au-dessus de deux montagnes.",
-        "caption": "Image en largeur normale et en 4x3",
+        "caption": "Image en largeur normale et en 4x3 et <b>en gras</b>",
         "image_url": "/django-dsfr/static/img/placeholder.16x9.svg",
         "ratio_class": "fr-ratio-4x3",
     }
@@ -597,14 +668,32 @@ class DsfrContentTagTest(SimpleTestCase):
         rendered_template = self.template_to_render.render(self.context)
         self.assertInHTML(
             """
-            <figure class="fr-content-media" role="group" aria-label="Image en largeur normale et en 4x3">
+            <figure class="fr-content-media" role="group" aria-label="Image en largeur normale et en 4x3 et <b>en gras</b>">
             <div class="fr-content-media__img">
                 <img class="fr-responsive-img fr-ratio-4x3"
                     src="/django-dsfr/static/img/placeholder.16x9.svg"
                     alt="Silhouette stylisée représentant le soleil au-dessus de deux montagnes." />
             </div>
                 <figcaption class="fr-content-media__caption">
-                Image en largeur normale et en 4x3
+                Image en largeur normale et en 4x3 et <b>en gras</b>
+                </figcaption>
+            </figure>""",
+            rendered_template,
+        )
+
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_content_tag_rendered_unsafe(self):
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """
+            <figure class="fr-content-media" role="group" aria-label="Image en largeur normale et en 4x3 et &lt;b&gt;en gras&lt;/b&gt;">
+            <div class="fr-content-media__img">
+                <img class="fr-responsive-img fr-ratio-4x3"
+                    src="/django-dsfr/static/img/placeholder.16x9.svg"
+                    alt="Silhouette stylisée représentant le soleil au-dessus de deux montagnes." />
+            </div>
+                <figcaption class="fr-content-media__caption">
+                Image en largeur normale et en 4x3 et &lt;b&gt;en gras&lt;/b&gt;
                 </figcaption>
             </figure>""",
             rendered_template,
@@ -673,7 +762,7 @@ class DsfrFranceConnectPlusTagTest(SimpleTestCase):
 
 class DsfrHighlightTagTest(SimpleTestCase):
     test_data = {
-        "content": "Content of the highlight item (can include html)",
+        "content": "Content of the highlight item (can include <b>html</b>)",
         "title": "(Optional) Title of the highlight item",
         "heading_tag": "h4",
         "size_class": "fr-text--sm",
@@ -688,7 +777,21 @@ class DsfrHighlightTagTest(SimpleTestCase):
             """
             <div class="fr-highlight">
                 <p class="fr-text--sm">
-                    Content of the highlight item (can include html)
+                    Content of the highlight item (can include <b>html</b>)
+                </p>
+            </div>
+            """,
+            rendered_template,
+        )
+
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_highlight_tag_rendered_unsafe(self):
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """
+            <div class="fr-highlight">
+                <p class="fr-text--sm">
+                    Content of the highlight item (can include &lt;b&gt;html&lt;/b&gt;)
                 </p>
             </div>
             """,
@@ -843,6 +946,30 @@ class DsfrNoticeTagTest(SimpleTestCase):
                             rel='noopener external'
                             title="intitulé - Ouvre une nouvelle fenêtre" target='_blank'>
                             lien</a>.
+                    </span>
+                </p>
+                    <button class="fr-btn--close fr-btn"
+                        title="Masquer le message"
+                        onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)">
+                    Masquer le message
+                    </button>
+                </div>
+            """,  # noqa
+            rendered_template,
+        )
+
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_notice_tag_rendered_unsafe(self):
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """
+            <div class="fr-notice__body">
+                <p>
+                    <span class="fr-notice__title">
+                        Bandeau d’information importante avec &lt;a href='#'
+                            rel='noopener external'
+                            title="intitulé - Ouvre une nouvelle fenêtre" target='_blank'&gt;
+                            lien&lt;/a&gt;.
                     </span>
                 </p>
                     <button class="fr-btn--close fr-btn"
@@ -1099,6 +1226,96 @@ class DsfrSkiplinksTagTest(SimpleTestCase):
         )
 
 
+class DsfrTableTagTest(SimpleTestCase):
+    test_data = {
+        "caption": "Tableau basique",
+        "header": ["Colonne 1", "Colonne 2", "Colonne 3"],
+        "content": [["a", "<b>b</b>", "c"], ["d", "e", "f"]],
+        "extra_classes": "fr-table--sm",
+    }
+
+    def test_table_rendered(self):
+        context = Context({"test_data": self.test_data})
+        template_to_render = Template("{% load dsfr_tags %} {% dsfr_table test_data %}")
+        rendered_template = template_to_render.render(context)
+        self.assertInHTML(
+            """
+            <div class="fr-table fr-table--sm">
+  <div class="fr-table__wrapper">
+    <div class="fr-table__container">
+      <div class="fr-table__content">
+        <table>
+          <caption>Tableau basique</caption>
+            <thead>
+              <tr>
+                  <th scope="col">Colonne 1</th>
+                  <th scope="col">Colonne 2</th>
+                  <th scope="col">Colonne 3</th>
+              </tr>
+            </thead>
+          <tbody>
+              <tr>
+                  <td>a</td>
+                  <td><b>b</b></td>
+                  <td>c</td>
+              </tr>
+              <tr>
+                  <td>d</td>
+                  <td>e</td>
+                  <td>f</td>
+              </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+            """,
+            rendered_template,
+        )
+
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_table_rendered_unsafe(self):
+        context = Context({"test_data": self.test_data})
+        template_to_render = Template("{% load dsfr_tags %} {% dsfr_table test_data %}")
+        rendered_template = template_to_render.render(context)
+        self.assertInHTML(
+            """
+            <div class="fr-table fr-table--sm">
+  <div class="fr-table__wrapper">
+    <div class="fr-table__container">
+      <div class="fr-table__content">
+        <table>
+          <caption>Tableau basique</caption>
+            <thead>
+              <tr>
+                  <th scope="col">Colonne 1</th>
+                  <th scope="col">Colonne 2</th>
+                  <th scope="col">Colonne 3</th>
+              </tr>
+            </thead>
+          <tbody>
+              <tr>
+                  <td>a</td>
+                  <td>&lt;b&gt;b&lt;/b&gt;</td>
+                  <td>c</td>
+              </tr>
+              <tr>
+                  <td>d</td>
+                  <td>e</td>
+                  <td>f</td>
+              </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+            """,
+            rendered_template,
+        )
+
+
 class DsfrTagTagTest(SimpleTestCase):
     def test_basic_tag_rendered(self):
         test_data = {
@@ -1321,6 +1538,63 @@ class DsfrTranscriptionTagTest(SimpleTestCase):
                                                 Transcription
                                             </h2>
                                             <div><p>Courte transcription basique</p></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </dialog>
+                </div>
+            </div>
+            """,  # noqa
+            rendered_template,
+        )
+
+    @override_settings(DSFR_CONTENT_IS_SAFE=False)
+    def test_summary_tag_rendered_unsafe(self):
+        rendered_template = self.template_to_render.render(self.context)
+        self.assertInHTML(
+            """
+            <div class="fr-transcription">
+                <button class="fr-transcription__btn"
+                        aria-expanded="false"
+                        aria-controls="fr-transcription__collapse-transcription-test">
+                    Transcription
+                </button>
+                <div class="fr-collapse" id="fr-transcription__collapse-transcription-test">
+                    <div class="fr-transcription__footer">
+                        <div class="fr-transcription__actions-group">
+
+                            <button class="fr-btn fr-btn--fullscreen"
+                                    aria-controls="fr-transcription-modal-transcription-test"
+                                    data-fr-opened="false"
+                                    title="Agrandir">
+                                Agrandir
+                            </button>
+                        </div>
+                    </div>
+                    <dialog id="fr-transcription-modal-transcription-test"
+                            class="fr-modal"
+                            role="dialog"
+                            aria-labelledby="fr-transcription-modal-transcription-test-title">
+                        <div class="fr-container fr-container--fluid fr-container-md">
+                            <div class="fr-grid-row fr-grid-row--center">
+                                <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+                                    <div class="fr-modal__body">
+                                        <div class="fr-modal__header">
+
+                                            <button class="fr-btn--close fr-btn"
+                                                    aria-controls="fr-transcription-modal-transcription-test"
+                                                    title="Fermer">
+                                                Fermer
+                                            </button>
+                                        </div>
+                                        <div class="fr-modal__content">
+                                            <h2 id="fr-transcription-modal-transcription-test-title"
+                                                class="fr-modal__title">
+                                                Transcription
+                                            </h2>
+                                            &lt;div&gt;&lt;p&gt;Courte transcription basique&lt;/p&gt;&lt;/div&gt;
                                         </div>
                                     </div>
                                 </div>

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ generate_secret_key:
 
 # Instantiate the project
 init:
-    uv sync
+    uv sync --dev --all-extras
     uv run pre-commit install
     uv run python manage.py migrate
     just collectstatic


### PR DESCRIPTION
## 🎯 Objectif

Closes #299 

Cette PR permet de décider, au niveau d'un projet Django, si les composants DSFR vont ou non échapper (appliquer le template filter [`safe`](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#safe)) les contenus qu'ils affichent.

## 🔍 Implémentation

- Création d'un template filter `dsfr_maybe_safe` qui applique `safe` seulement si le réglage `DSFR_CONTENT_IS_SAFE` est à `True`
- Remplacement de toutes les occurrences de `safe` par `dsfr_maybe_safe` dans **les templates des composants** (pas les templates de layout qui affichent les contenus gérées par `DsfrConfig`)

## ⚠️ Informations supplémentaires

C'est à débattre.

## 🏕 Amélioration continue

- Couverture basique en tests du composant `dsfr_table`
- Amélioration du script d'installation initiale
